### PR TITLE
メモブロックに画像とYouTubeの埋め込みを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ node_modules
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
 
+/.env

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,10 @@ gem 'meta-tags'
 
 gem 'rails-i18n'
 
+gem 'aws-sdk-s3', require: false
+
+gem 'dotenv-rails'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,6 +69,22 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.864.0)
+    aws-sdk-core (3.190.0)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.74.0)
+      aws-sdk-core (~> 3, >= 3.188.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.141.0)
+      aws-sdk-core (~> 3, >= 3.189.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.1.1)
     bcrypt (3.1.19)
     bindex (0.8.1)
@@ -91,6 +107,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     dry-cli (1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
@@ -118,6 +138,7 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    jmespath (1.6.2)
     json (2.6.3)
     jwt (2.7.1)
     kaminari (1.2.2)
@@ -329,9 +350,11 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  aws-sdk-s3
   bootsnap
   capybara
   debug
+  dotenv-rails
   factory_bot_rails
   faker
   foreman

--- a/app/controllers/api/memo_blocks_controller.rb
+++ b/app/controllers/api/memo_blocks_controller.rb
@@ -58,6 +58,8 @@ class Api::MemoBlocksController < ApplicationController
   def blockable_params
     if params.key?(:sentence)
       sentence_params
+    elsif params.key?(:image)
+      image_params
     else
       raise ActionController::ParameterMissing, :blockable
     end
@@ -65,5 +67,9 @@ class Api::MemoBlocksController < ApplicationController
 
   def sentence_params
     params.require(:sentence).permit(:subtitle, :body)
+  end
+
+  def image_params
+    params.require(:image).permit(:subtitle, pictures: [])
   end
 end

--- a/app/controllers/api/memo_blocks_controller.rb
+++ b/app/controllers/api/memo_blocks_controller.rb
@@ -21,18 +21,24 @@ class Api::MemoBlocksController < ApplicationController
       @memo_block.insert_and_save!
     end
 
-    if @memo_block.blockable.update(blockable_params)
-      render json: @memo_block, include: [:blockable]
+    @blockable = @memo_block.blockable
+
+    if @blockable.update(blockable_params)
+      @blockable.parse_base64(image_params[:file]) if params.key?(:image)
+      render json: @memo_block, include: [{blockable: {methods: :picture_url}}]
     else
-      render json: @memo_block.blockable.errors.full_messages, status: :bad_request
+      render json: @blockable.errors.full_messages, status: :bad_request
     end
   end
 
   def update
-    if @memo_block.blockable.update(blockable_params)
-      render json: @memo_block, include: [:blockable]
+    @blockable = @memo_block.blockable
+
+    if @blockable.update(blockable_params)
+      @blockable.parse_base64(image_params[:file]) if params.key?(:image)
+      render json: @memo_block, include: [{blockable: {methods: :picture_url}}]
     else
-      render json: @memo_block.blockable.errors.full_messages, status: :bad_request
+      render json: @blockable.errors.full_messages, status: :bad_request
     end
   end
 
@@ -70,6 +76,6 @@ class Api::MemoBlocksController < ApplicationController
   end
 
   def image_params
-    params.require(:image).permit(:subtitle, pictures: [])
+    params.require(:image).permit(:subtitle, :file, :picture_width)
   end
 end

--- a/app/controllers/api/memo_blocks_controller.rb
+++ b/app/controllers/api/memo_blocks_controller.rb
@@ -66,6 +66,8 @@ class Api::MemoBlocksController < ApplicationController
       sentence_params
     elsif params.key?(:image)
       image_params
+    elsif params.key?(:embed)
+      embed_params
     else
       raise ActionController::ParameterMissing, :blockable
     end
@@ -77,5 +79,9 @@ class Api::MemoBlocksController < ApplicationController
 
   def image_params
     params.require(:image).permit(:subtitle, :file, :picture_width)
+  end
+
+  def embed_params
+    params.require(:embed).permit(:subtitle, :embed_type, :identifier)
   end
 end

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -12,14 +12,14 @@ class Api::MemosController < ApplicationController
     @memo.title = Fighter.find(@memo.fighter_id).name if @memo.title.blank?
 
     if @memo.save
-      render json: @memo, include: [{memo_blocks: {include: [:blockable]}}]
+      render json: @memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}]
     else
       render json: @memo.errors.full_messages, status: :bad_request
     end
   end
 
   def show
-    render json: @memo, include: [{memo_blocks: {include: [:blockable]}}]
+    render json: @memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}]
   end
 
   def update
@@ -27,7 +27,7 @@ class Api::MemosController < ApplicationController
     @memo.title = Fighter.find(@memo.fighter_id).name if @memo.title.blank?
 
     if @memo.save
-      render json: @memo, include: [{memo_blocks: {include: [:blockable]}}]
+      render json: @memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}]
     else
       render json: @memo.errors.full_messages, status: :bad_request
     end

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -49,6 +49,6 @@ class Api::MemosController < ApplicationController
   end
 
   def memo_params
-    params.require(:memo).permit(:title, :type, :fighter_id)
+    params.require(:memo).permit(:title, :type, :fighter_id, :state)
   end
 end

--- a/app/controllers/concerns/api/user_authenticator.rb
+++ b/app/controllers/concerns/api/user_authenticator.rb
@@ -7,7 +7,7 @@ module Api::UserAuthenticator
 
     payload, = User.decode bearer_token
     @current_user ||= User.find_by(id: payload['user_id'])
-  rescue JWT::ExpiredSignature
+  rescue JWT::ExpiredSignature, JWT::VerificationError
     nil
   end
 

--- a/app/frontend/components/TheHeader.vue
+++ b/app/frontend/components/TheHeader.vue
@@ -58,12 +58,12 @@
 </template>
 
 <script>
-import TheSidebarList from './TheSidebarList';
 import { mapGetters, mapActions } from 'vuex';
 import {
   successLogoutAlertStatus,
   serverErrorAlertStatus
 } from '../constants/alertStatus';
+import TheSidebarList from './TheSidebarList';
 
 export default {
   name: "TheHeader",

--- a/app/frontend/constants/validationCustom.js
+++ b/app/frontend/constants/validationCustom.js
@@ -1,5 +1,11 @@
-// バリデーションのエラーメッセージ
+import { helpers } from '@vuelidate/validators';
 
+export const image = (value) => {
+  const pattern = /^data:image\/(jpeg|jpg|png);base64,/;
+  return value.match(pattern) || !helpers.req(value);
+};
+
+// バリデーションのエラーメッセージ
 export const requiredMessage = (value) => `${value}は必須項目です`;
 
 export const emailMessage = () => "メールアドレスの形式が正しくありません";

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="text-md-h3 text-h4 font-weight-bold">
-    キャラ対メモ
+    {{ pageInformation.pageTitle }}
   </div>
 
   <div class="my-6" />
@@ -36,7 +36,7 @@
               <v-list-item
                 :title="folderItem.name"
                 :subtitle="dateFormat(folderItem.updatedAt)"
-                :to="{ path: `/matchup/${folderItem.id}/memos` }"
+                :to="{ path: `/${pageInformation.pathPrefix}/${folderItem.id}/memos` }"
                 :prepend-icon="mdiFolder"
               />
               <v-btn
@@ -172,16 +172,25 @@ import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import FolderFormDialog from '../components/FolderFormDialog';
 
 export default {
-  name: "MatchupFoldersIndex",
+  name: "FoldersIndex",
   components: {
     FolderFormDialog
   },
   data() {
     return {
+      pageInformationMatchup: {
+        pageTitle: "キャラ対メモ",
+        pathPrefix: "matchup",
+        folderType: "MatchupFolder"
+      },
+      pageInformationStrategy: {
+        pageTitle: "攻略メモ",
+        pathPrefix: "strategy",
+        folderType: "StrategyFolder"
+      },
       folderCreateDialog: false,
       folderEditDialog: false,
       folderDeleteDialog: false,
-      folderType: "MatchupFolder",
       folderDefault: {
         id: null,
         name: "",
@@ -194,6 +203,12 @@ export default {
   },
   computed: {
     ...mapGetters("folders", ["folders"]),
+    isMatchup() {
+      return (this.$route.name == "MatchupFoldersIndex") ? true : false;
+    },
+    pageInformation() {
+      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+    },
     sortedFolders() {
       return this.folders.slice().sort((a, b) => {
         if (a.updatedAt > b.updatedAt) return -1;
@@ -203,7 +218,7 @@ export default {
     }
   },
   created() {
-    this.$store.dispatch("folders/fetchFolders", this.folderType);
+    this.$store.dispatch("folders/fetchFolders", this.pageInformation.folderType);
   },
   methods: {
     ...mapActions("folders", [
@@ -234,7 +249,7 @@ export default {
       try {
         await this.createFolder({
           folder: folder,
-          folderType: this.folderType
+          folderType: this.pageInformation.folderType
         });
         this.handleCloseFolderDialog();
       } catch (error) {

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -226,7 +226,10 @@ export default {
       "updateFolder",
       "deleteFolder"
     ]),
-    ...mapActions("alert", ["displayAlert"]),
+    ...mapActions("alert", [
+      "displayAlert",
+      "closeAlertWithCross"
+    ]),
     handleOpenFolderCreateDialog() {
       this.folder = Object.assign({}, this.folderDefault);
       this.folderCreateDialog = true;
@@ -240,6 +243,7 @@ export default {
       this.folderDeleteDialog = true;
     },
     handleCloseFolderDialog() {
+      this.closeAlertWithCross();
       this.folder = Object.assign({}, this.folderDefault);
       this.folderCreateDialog = false;
       this.folderEditDialog = false;

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -166,10 +166,10 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
-import dayjs from 'dayjs';
 import { mdiFolder, mdiInformationOutline } from '@mdi/js';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import FolderFormDialog from '../components/FolderFormDialog';
+import dayjs from 'dayjs';
 
 export default {
   name: "FoldersIndex",

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -238,7 +238,8 @@ export default {
       imageDefault: {
         subtitle: "",
         file: "",
-        pictureWidth: 500
+        pictureWidth: 500,
+        pictureUrl: ""
       },
       embedDefault: {
         subtitle: ""

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -164,11 +164,11 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
-import sanitizeText from '../../../plugins/sanitizeText';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import MemoBlockFormDialog from '../components/MemoBlockFormDialog';
 import MemoEditForm from '../components/MemoEditForm';
 import EmbedYoutube from '../components/EmbedYoutube';
+import sanitizeText from '../../../plugins/sanitizeText';
 
 export default {
   name: "MemosEdit",

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -24,7 +24,12 @@
             <template v-if="memoBlockItem.blockableType == 'Sentence'">
               <p v-html="sanitizeHtml(memoBlockItem.blockable.body)" />
             </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Image'" />
+            <template v-else-if="memoBlockItem.blockableType == 'Image'">
+              <v-img
+                :src="memoBlockItem.blockable.pictureUrl"
+                :width="memoBlockItem.blockable.pictureWidth"
+              />
+            </template>
             <template v-else-if="memoBlockItem.blockableType == 'Embed'" />
           </v-card-text>
           <v-card-actions>
@@ -232,7 +237,8 @@ export default {
       },
       imageDefault: {
         subtitle: "",
-        picture: null
+        file: "",
+        pictureWidth: 500
       },
       embedDefault: {
         subtitle: ""

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -30,7 +30,11 @@
                 :width="memoBlockItem.blockable.pictureWidth"
               />
             </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Embed'" />
+            <template v-else-if="memoBlockItem.blockableType == 'Embed'">
+              <EmbedYoutube
+                :youtube-url="memoBlockItem.blockable.identifier"
+              />
+            </template>
           </v-card-text>
           <v-card-actions>
             <v-spacer />
@@ -90,29 +94,10 @@
         :sentence="sentence"
         :image="image"
         :embed="embed"
+        :is-edit="false"
         @close-dialog="handleCloseMemoBlockDialog"
         @memoblock-submit="handleMemoBlockCreate"
       >
-        <template #radio-button>
-          <v-radio-group
-            v-model="memoBlock.blockableType"
-            inline
-            class="ml-4"
-          >
-            <v-radio
-              label="テキスト"
-              value="Sentence"
-            />
-            <v-radio
-              label="画像"
-              value="Image"
-            />
-            <v-radio
-              label="埋め込み"
-              value="Embed"
-            />
-          </v-radio-group>
-        </template>
         <template #title>
           メモブロックの追加
         </template>
@@ -133,30 +118,10 @@
         :sentence="sentence"
         :image="image"
         :embed="embed"
+        :is-edit="true"
         @close-dialog="handleCloseMemoBlockDialog"
         @memoblock-submit="handleMemoBlockUpdate"
       >
-        <template #radio-button>
-          <v-radio-group
-            v-model="memoBlock.blockableType"
-            inline
-            disabled
-            class="ml-4"
-          >
-            <v-radio
-              label="テキスト"
-              value="Sentence"
-            />
-            <v-radio
-              label="画像"
-              value="Image"
-            />
-            <v-radio
-              label="埋め込み"
-              value="Embed"
-            />
-          </v-radio-group>
-        </template>
         <template #title>
           メモブロックの編集
         </template>
@@ -203,12 +168,14 @@ import sanitizeText from '../../../plugins/sanitizeText';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import MemoBlockFormDialog from '../components/MemoBlockFormDialog';
 import MemoEditForm from '../components/MemoEditForm';
+import EmbedYoutube from '../components/EmbedYoutube';
 
 export default {
   name: "MemosEdit",
   components: {
     MemoBlockFormDialog,
-    MemoEditForm
+    MemoEditForm,
+    EmbedYoutube
   },
   data() {
     return {
@@ -242,7 +209,9 @@ export default {
         pictureUrl: ""
       },
       embedDefault: {
-        subtitle: ""
+        subtitle: "",
+        embedType: "youtube",
+        identifier: ""
       },
       memoBlock: {},
       sentence: {},

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -61,7 +61,6 @@
     >
       <MemoEditForm
         :memo="memo"
-        :is-matchup="isMatchup"
         @memo-submit="handleMemoUpdate"
       />
       <router-link
@@ -208,10 +207,15 @@ export default {
   },
   data() {
     return {
+      pageInformationMatchup: {
+        showRouteName: "MatchupMemosShow"
+      },
+      pageInformationStrategy: {
+        showRouteName: "StrategyMemosShow"
+      },
       memoBlockCreateDialog: false,
       memoBlockEditDialog: false,
       memoBlockDeleteDialog: false,
-      pageInformation: {},
       memo: {
         title: "",
         fighterId: null,
@@ -219,7 +223,7 @@ export default {
       },
       memoBlockDefault: {
         id: null,
-        levle: 0,
+        level: 0,
         blockableType: "Sentence"
       },
       sentenceDefault: {
@@ -227,7 +231,8 @@ export default {
         body: ""
       },
       imageDefault: {
-        subtitle: ""
+        subtitle: "",
+        picture: null
       },
       embedDefault: {
         subtitle: ""
@@ -243,6 +248,9 @@ export default {
     isMatchup() {
       return (this.$route.name == "MatchupMemosEdit") ? true : false;
     },
+    pageInformation() {
+      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+    },
     memoId() {
       return this.$route.params.memoId;
     }
@@ -251,13 +259,6 @@ export default {
     this.$store.dispatch("memos/fetchMemoDetail", this.$route.params.memoId)
       .then(() => {
         this.memo = Object.assign({}, this.memoDetail);
-        if (this.isMatchup) {
-          this.pageInformation = {
-            showRouteName: "MatchupMemosShow"
-          };
-        } else {
-          this.pageInformation = {};
-        }
       })
       .catch(() => {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -281,7 +281,10 @@ export default {
       "updateMemoBlock",
       "deleteMemoBlock"
     ]),
-    ...mapActions("alert", ["displayAlert"]),
+    ...mapActions("alert", [
+      "displayAlert",
+      "closeAlertWithCross"
+    ]),
     handleOpenMemoBlockCreateDialog() {
       this.memoBlockInitialize();
       this.memoBlockCreateDialog = true;
@@ -311,6 +314,7 @@ export default {
       this.memoBlockDeleteDialog = true;
     },
     handleCloseMemoBlockDialog() {
+      this.closeAlertWithCross();
       this.memoBlockInitialize();
       this.memoBlockCreateDialog = false;
       this.memoBlockEditDialog = false;

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -178,10 +178,10 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
-import dayjs from 'dayjs';
 import { mdiFile, mdiInformationOutline } from '@mdi/js';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import MemoCreateFormDialog from '../components/MemoCreateFormDialog';
+import dayjs from 'dayjs';
 
 export default {
   name: "MemosIndex",

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -248,7 +248,10 @@ export default {
       "createMemo",
       "deleteMemo"
     ]),
-    ...mapActions("alert", ["displayAlert"]),
+    ...mapActions("alert", [
+      "displayAlert",
+      "closeAlertWithCross"
+    ]),
     handleOpenMemoCreateDialog() {
       this.memo = Object.assign({}, this.memoDefault);
       this.memoCreateDialog = true;
@@ -258,6 +261,7 @@ export default {
       this.memoDeleteDialog = true;
     },
     handleCloseMemoDialog() {
+      this.closeAlertWithCross();
       this.memo = Object.assign({}, this.memoDefault);
       this.memoCreateDialog = false;
       this.memoDeleteDialog = false;

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -20,24 +20,35 @@
           </span>
           <v-spacer />
           <div>
-            <div>
+            <template v-if="isMatchup">
+              <div>
+                <v-btn
+                  size="small"
+                  color="teal-accent-4"
+                  class="mb-2"
+                >
+                  テンプレートの編集
+                </v-btn>
+              </div>
+              <div>
+                <v-btn
+                  size="small"
+                  color="teal-accent-4"
+                  @click="handleOpenMemoCreateDialog"
+                >
+                  メモの作成
+                </v-btn>
+              </div>
+            </template>
+            <template v-else>
               <v-btn
-                size="small"
                 color="teal-accent-4"
-                class="mb-2"
-              >
-                テンプレートの編集
-              </v-btn>
-            </div>
-            <div>
-              <v-btn
-                size="small"
-                color="teal-accent-4"
+                class="mb-2 mr-2"
                 @click="handleOpenMemoCreateDialog"
               >
                 メモの作成
               </v-btn>
-            </div>
+            </template>
           </div>
         </div>
         <v-list lines="two">
@@ -49,7 +60,7 @@
               <v-list-item
                 :title="memoItem.title"
                 :subtitle="dateFormat(memoItem.updatedAt)"
-                :to="{ path: `/matchup/memos/${memoItem.id}` }"
+                :to="{ path: `/${pageInformation.pathPrefix}/memos/${memoItem.id}` }"
                 :prepend-icon="mdiFile"
               />
               <v-btn
@@ -61,7 +72,9 @@
                 <v-icon :icon="mdiInformationOutline" />
                 <v-menu activator="parent">
                   <v-list density="compact">
-                    <v-list-item :to="{ name: 'MatchupMemosEdit', params: { memoId: memoItem.id } }">
+                    <v-list-item
+                      :to="{ name: pageInformation.editRouteName, params: { memoId: memoItem.id } }"
+                    >
                       <v-list-item-title>
                         <span>
                           メモを編集する
@@ -86,11 +99,13 @@
       <template v-else>
         <div class="text-body-1 font-weight-bold">
           まだ、メモがありません。
-          メモの作成からキャラ対メモを追加しましょう。
+          メモの作成から{{ pageInformation.memoCategory }}を追加しましょう。
 
-          <div class="my-8" />
+          <template v-if="isMatchup">
+            <div class="my-8" />
 
-          テンプレート機能を使うと、キャラ対メモの作成時にテンプレートに設定した内容が自動的に追加されます。
+            テンプレート機能を使うと、キャラ対メモの作成時にテンプレートに設定した内容が自動的に追加されます。
+          </template>
         </div>
 
         <div class="my-8" />
@@ -104,12 +119,14 @@
             >
               メモの作成
             </v-btn>
-            <v-btn
-              class="mb-2"
-              color="teal-accent-4"
-            >
-              テンプレートの編集
-            </v-btn>
+            <template v-if="isMatchup">
+              <v-btn
+                class="mb-2"
+                color="teal-accent-4"
+              >
+                テンプレートの編集
+              </v-btn>
+            </template>
           </div>
         </v-layout>
       </template>
@@ -167,19 +184,30 @@ import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import MemoCreateFormDialog from '../components/MemoCreateFormDialog';
 
 export default {
-  name: "MatchupMemosIndex",
+  name: "MemosIndex",
   components: {
     MemoCreateFormDialog
   },
   data() {
     return {
+      pageInformationMatchup: {
+        memoCategory: "キャラ対メモ",
+        memoType: "MatchupMemo",
+        pathPrefix: "matchup",
+        editRouteName: "MatchupMemosEdit"
+      },
+      pageInformationStrategy: {
+        memoCategory: "攻略メモ",
+        memoType: "StrategyMemo",
+        pathPrefix: "strategy",
+        editRouteName: "StrategyMemosEdit"
+      },
       memoDefault: {
         id: null,
         title: "",
         fighterId: null
       },
       memo: {},
-      memoType: "MatchupMemo",
       memoCreateDialog: false,
       memoDeleteDialog: false,
       mdiFile,
@@ -191,6 +219,12 @@ export default {
       "folderName",
       "memos"
     ]),
+    isMatchup() {
+      return (this.$route.name == "MatchupMemosIndex") ? true : false;
+    },
+    pageInformation() {
+      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+    },
     folderId() {
       return this.$route.params.folderId;
     },
@@ -232,7 +266,7 @@ export default {
       try {
         await this.createMemo({
           memo: memo,
-          memoType: this.memoType,
+          memoType: this.pageInformation.memoType,
           folderId: this.folderId,
           applyTemplate: applyTemplate
         });

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -86,6 +86,33 @@
         </v-layout>
       </template>
     </v-col>
+    <template v-if="$vuetify.display.mdAndUp">
+      <v-col
+        md="4"
+        lg="4"
+        xl="4"
+      >
+        <router-link
+          :to="{ name: pageInformation.editRouteName, params: { memoId: memoDetail.id }}"
+        >
+          <v-btn
+            block
+            color="teal-accent-4"
+            class="mt-4"
+          >
+            メモを編集する
+          </v-btn>
+        </router-link>
+        <v-btn
+          block
+          color="error"
+          class="mt-4"
+          @click="handleOpenMemoDeleteDialog"
+        >
+          メモを削除する
+        </v-btn>
+      </v-col>
+    </template>
   </v-row>
 
   <div class="justify-center">
@@ -120,9 +147,9 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
-import sanitizeText from '../../../plugins/sanitizeText';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import EmbedYoutube from '../components/EmbedYoutube';
+import sanitizeText from '../../../plugins/sanitizeText';
 
 export default {
   name: "MemosEdit",

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -29,7 +29,12 @@
                 v-html="sanitizeHtml(memoBlockItem.blockable.body)"
               />
             </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Image'" />
+            <template v-else-if="memoBlockItem.blockableType == 'Image'">
+              <v-img
+                :src="memoBlockItem.blockable.pictureUrl"
+                :width="memoBlockItem.blockable.pictureWidth"
+              />
+            </template>
             <template v-else-if="memoBlockItem.blockableType == 'Embed'" />
           </template>
         </div>

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -33,9 +33,16 @@
               <v-img
                 :src="memoBlockItem.blockable.pictureUrl"
                 :width="memoBlockItem.blockable.pictureWidth"
+                class="ml-2 mt-n2 mb-4"
               />
             </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Embed'" />
+            <template v-else-if="memoBlockItem.blockableType == 'Embed'">
+              <div class="ml-2 mt-n2 mb-4">
+                <EmbedYoutube
+                  :youtube-url="memoBlockItem.blockable.identifier"
+                />
+              </div>
+            </template>
           </template>
         </div>
         <div class="d-flex flex-row justify-end mt-8">
@@ -115,9 +122,13 @@
 import { mapGetters, mapActions } from 'vuex';
 import sanitizeText from '../../../plugins/sanitizeText';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
+import EmbedYoutube from '../components/EmbedYoutube';
 
 export default {
   name: "MemosEdit",
+  components: {
+    EmbedYoutube
+  },
   data() {
     return {
       pageInformationMatchup: {

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -152,11 +152,15 @@ export default {
   },
   methods: {
     ...mapActions("memos", ["deleteMemo"]),
-    ...mapActions("alert", ["displayAlert"]),
+    ...mapActions("alert", [
+      "displayAlert",
+      "closeAlertWithCross"
+    ]),
     handleOpenMemoDeleteDialog() {
       this.memoDeleteDialog = true;
     },
     handleCloseMemoDialog() {
+      this.closeAlertWithCross();
       this.memoDeleteDialog = false;
     },
     async handleMemoDelete() {

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -18,12 +18,14 @@
             v-for="memoBlockItem in memoDetail.memoBlocks"
             :key="memoBlockItem.id"
           >
-            <div class="text-md-h5 text-h6 mb-2">
-              {{ memoBlockItem.blockable.subtitle }}
-            </div>
+            <template v-if="!(memoBlockItem.blockable.subtitle == '')">
+              <div class="text-md-h5 text-h6 mb-4">
+                {{ memoBlockItem.blockable.subtitle }}
+              </div>
+            </template>
             <template v-if="memoBlockItem.blockableType == 'Sentence'">
               <div
-                class="ml-2 mb-6 sentence-body"
+                class="ml-2 mt-n2 mb-4 sentence-body"
                 v-html="sanitizeHtml(memoBlockItem.blockable.body)"
               />
             </template>
@@ -113,8 +115,15 @@ export default {
   name: "MemosEdit",
   data() {
     return {
+      pageInformationMatchup: {
+        indexRouteName: "MatchupMemosIndex",
+        editRouteName: "MatchupMemosEdit"
+      },
+      pageInformationStrategy: {
+        indexRouteName: "StrategyMemosIndex",
+        editRouteName: "StrategyMemosEdit"
+      },
       memoDeleteDialog: false,
-      pageInformation: {}
     };
   },
   computed: {
@@ -122,22 +131,15 @@ export default {
     isMatchup() {
       return (this.$route.name == "MatchupMemosShow") ? true : false;
     },
+    pageInformation() {
+      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+    },
     memoId() {
       return this.$route.params.memoId;
     }
   },
   created() {
     this.$store.dispatch("memos/fetchMemoDetail", this.$route.params.memoId)
-      .then(() => {
-        if (this.isMatchup) {
-          this.pageInformation = {
-            editRouteName: "MatchupMemosEdit",
-            indexRouteName: "MatchupMemosIndex"
-          };
-        } else {
-          this.pageInformation = {};
-        }
-      })
       .catch(() => {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });
         this.$router.push({ name: "TopIndex" });

--- a/app/frontend/pages/memos/components/EmbedYoutube.vue
+++ b/app/frontend/pages/memos/components/EmbedYoutube.vue
@@ -1,0 +1,60 @@
+<template>
+  <iframe
+    :width="playerWidth"
+    :src="embedYoutubeUrl"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture;"
+    allowfullscreen
+  />
+</template>
+
+<script>
+export default {
+  name: "EmbedYoutube",
+  props: {
+    youtubeUrl : {
+      type: String,
+      required: true
+    }
+  },
+  data() {
+    return {
+      embedYoutubeUrl : ""
+    }
+  },
+  computed: {
+    playerWidth() {
+      switch (this.$vuetify.display.name) {
+        case "xs": return "100%";
+        default: return "560px";
+      }
+    },
+  },
+  mounted() {
+    this.embedYoutubeUrl = this.getYoutubeEmbedUrl(this.youtubeUrl);
+  },
+  methods: {
+    getYoutubeEmbedUrl(url) {
+      let result = "";
+
+      const videoIndex = url.split("/").pop().replace("watch?v=", "").split(/[?&]/);
+      result = result + videoIndex[0] + "?";
+
+      const params = videoIndex.filter((param) => /^(list=|t=)/.test(param));
+      params.forEach((param) => {
+        param.replace("t=", "amp;start=");
+        result = result + param + "&";
+      })
+
+      result = "https://www.youtube.com/embed/" + result.slice(0, -1);
+      return result;
+    }
+  }
+};
+</script>
+
+<style scoped>
+iframe{
+  aspect-ratio: 16 / 9;
+  border: none;
+}
+</style>

--- a/app/frontend/pages/memos/components/FolderFormDialog.vue
+++ b/app/frontend/pages/memos/components/FolderFormDialog.vue
@@ -53,7 +53,7 @@ import {
   maxLength,
   helpers
 } from '@vuelidate/validators';
-import { requiredMessage, maxLengthMessage } from '../../../constants/validationMessages';
+import { requiredMessage, maxLengthMessage } from '../../../constants/validationCustom';
 import { FIGHTERS_ARRAY } from '../../../constants/fightersArray';
 import TheAlert from '../../../components/TheAlert';
 

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -6,7 +6,25 @@
     <v-card-text>
       <TheAlert :is-dialog="true" />
       <form>
-        <slot name="radio-button" />
+        <v-radio-group
+          v-model="v$.memoBlock.blockableType.$model"
+          inline
+          :disabled="isEdit"
+          class="ml-4"
+        >
+          <v-radio
+            label="テキスト"
+            value="Sentence"
+          />
+          <v-radio
+            label="画像"
+            value="Image"
+          />
+          <v-radio
+            label="埋め込み"
+            value="Embed"
+          />
+        </v-radio-group>
         <template v-if="memoBlock.blockableType == 'Sentence'">
           <v-text-field
             v-model="v$.sentence.subtitle.$model"
@@ -71,7 +89,65 @@
             class="w-75 ml-4"
           />
         </template>
-        <template v-else-if="memoBlock.blockableType == 'Embed'" />
+        <template v-else-if="memoBlock.blockableType == 'Embed'">
+          <v-text-field
+            v-model="v$.embed.subtitle.$model"
+            :error-messages="v$.embed.subtitle.$errors.map(e => e.$message)"
+            :counter="20"
+            name="見出し"
+            label="見出し"
+            hint="未入力にすることも可能です"
+            variant="underlined"
+            class="w-75 ml-4"
+          />
+          <v-text-field
+            v-model="v$.embed.identifier.$model"
+            :error-messages="v$.embed.identifier.$errors.map(e => e.$message)"
+            :counter="200"
+            clearable
+            name="埋め込み"
+            label="埋め込みURL"
+            hint="YouTubeのURLを入力してください"
+            variant="underlined"
+            class="w-75 ml-4"
+          >
+            <template #append>
+              <v-btn
+                icon
+                density="compact"
+                variant="plain"
+                @cllick="handleOpenEmbedYoutubeHelp"
+              >
+                <v-icon :icon="mdiHelpCircleOutline" />
+                <v-dialog
+                  v-model="embedYoutubeHelp"
+                  width="500px"
+                  activator="parent"
+                >
+                  <v-card>
+                    <v-card-title class="ma-2">
+                      <span class="text-h5 font-weight-bold">動画の埋め込み方法</span>
+                    </v-card-title>
+                    <v-card-text>
+                      YouTube動画ページ上部のURLか共有ボタンを押して表示されるURLをコピー&ペーストすることで、
+                      YouTubeの埋め込みを作成できます。
+
+                      <div class="my-4" />
+
+                      動画の開始位置の指定やプレイリストの埋め込みにも対応しています。
+                    </v-card-text>
+                    <v-card-actions>
+                      <v-spacer />
+                      <v-btn @click="embedYoutubeHelp = false">
+                        閉じる
+                      </v-btn>
+                    </v-card-actions>
+                  </v-card>
+                </v-dialog>
+              </v-btn>
+            </template>
+          </v-text-field>
+        </template>
       </form>
     </v-card-text>
     <v-card-actions>
@@ -93,6 +169,7 @@
 <script>
 import { useVuelidate } from '@vuelidate/core';
 import { maxLength, helpers } from '@vuelidate/validators';
+import { mdiHelpCircleOutline } from '@mdi/js';
 import { image, maxLengthMessage } from '../../../constants/validationCustom';
 import imageCompression from '../../../plugins/imageCompression';
 import TextEditor from '../../../components/TextEditor';
@@ -155,7 +232,19 @@ export default {
       subtitle: {
         type: String,
         default: ""
+      },
+      embedType: {
+        type: String,
+        default: "youtube",
+      },
+      identifier: {
+        type: String,
+        default: ""
       }
+    },
+    isEdit: {
+      type: Boolean,
+      required: true
     }
   },
   emits: [
@@ -170,7 +259,9 @@ export default {
   },
   data() {
     return {
-      formPreviewUrl: ""
+      formPreviewUrl: "",
+      embedYoutubeHelp: false,
+      mdiHelpCircleOutline
     };
   },
   computed: {
@@ -182,6 +273,9 @@ export default {
   },
   validations () {
     return {
+      memoBlock: {
+        blockableType: {}
+      },
       sentence: {
         subtitle: { 
           maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
@@ -198,6 +292,15 @@ export default {
           image: helpers.withMessage("無効なファイル形式です", image)
         },
         pictureWidth: {}
+      },
+      embed: {
+        subtitle: { 
+          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+        },
+        embedType: {},
+        identifier: {
+          maxLength: helpers.withMessage(maxLengthMessage(200), maxLength(200))
+        }
       }
     };
   },

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -169,11 +169,11 @@
 <script>
 import { useVuelidate } from '@vuelidate/core';
 import { maxLength, helpers } from '@vuelidate/validators';
-import { mdiHelpCircleOutline } from '@mdi/js';
 import { image, maxLengthMessage } from '../../../constants/validationCustom';
-import imageCompression from '../../../plugins/imageCompression';
+import { mdiHelpCircleOutline } from '@mdi/js';
 import TextEditor from '../../../components/TextEditor';
 import TheAlert from '../../../components/TheAlert';
+import imageCompression from '../../../plugins/imageCompression';
 
 export default {
   name: "MemoBlockFormDialog",

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -42,11 +42,12 @@
           <v-file-input
             label="ファイルを選択してください"
             show-size
+            prepend-icon=""
             variant="underlined"
             class="w-75 ml-4"
             @change="handleFileChange"
           />
-          <p class="text-body-2 font-weight-thin">
+          <p class="text-body-2 font-weight-thin ml-4">
             画像サイズ
           </p>
           <v-slider

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -28,7 +28,37 @@
             </p>
           </template>
         </template>
-        <template v-else-if="memoBlock.blockableType == 'Image'" />
+        <template v-else-if="memoBlock.blockableType == 'Image'">
+          <v-text-field
+            v-model="v$.image.subtitle.$model"
+            :error-messages="v$.image.subtitle.$errors.map(e => e.$message)"
+            :counter="20"
+            name="見出し"
+            label="見出し"
+            hint="未入力にすることも可能です"
+            variant="underlined"
+            class="w-75 ml-4"
+          />
+          <v-file-input
+            label="ファイルを選択してください"
+            show-size
+            variant="underlined"
+            class="w-75 ml-4"
+            @change="handleFileChange"
+          />
+          <p class="text-body-2 font-weight-thin">
+            画像サイズ
+          </p>
+          <v-slider
+            v-model="v$.image.pictureWidth.$model"
+            name="画像サイズ"
+            max="800"
+            min="200"
+            step="10"
+            thumb-label
+            class="w-75 ml-4"
+          />
+        </template>
         <template v-else-if="memoBlock.blockableType == 'Embed'" />
       </form>
     </v-card-text>
@@ -92,6 +122,14 @@ export default {
       subtitle: {
         type: String,
         default: ""
+      },
+      file: {
+        type: String,
+        default: ""
+      },
+      pictureWidth: {
+        type: Number,
+        default: 500
       }
     },
     embed: {
@@ -120,8 +158,15 @@ export default {
           maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
         },
         body: {
-          maxLength: helpers.withMessage("保存できる文字数を超えています", maxLength(65536))
+          maxLength: helpers.withMessage("保存できる文字数を超えています", maxLength(65535))
         }
+      },
+      image: {
+        subtitle: { 
+          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+        },
+        file: {},
+        pictureWidth: {}
       }
     };
   },
@@ -132,6 +177,15 @@ export default {
     },
     updateContent(newContent) {
       this.v$.sentence.body.$model = newContent;
+    },
+    handleFileChange(event) {
+      let file = event.target.files[0];
+      let reader = new FileReader();
+      reader.onload = (event) => {
+        const base64Data = event.target.result;
+        this.image.file = base64Data;
+      };
+      reader.readAsDataURL(file);
     },
     async handleMemoBlockSubmit() {
       const result = await this.v$.$validate();

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -15,24 +15,26 @@
           hint="未入力の場合、下記の相手ファイター名が設定されます"
           variant="underlined"
         />
-        <v-autocomplete
-          v-model="v$.memo.fighterId.$model"
-          :error-messages="v$.memo.fighterId.$errors.map(e => e.$message)"
-          :items="fightersArray"
-          item-value="id"
-          item-title="name"
-          clearable
-          :menu-props="{ location: 'top', scrollStrategy: 'none' }"
-          name="相手ファイター"
-          label="相手ファイター"
-          hint="対策するファイターを選択してください"
-          variant="underlined"
-        />
-        <v-checkbox
-          v-model="applyTemplate"
-          name="キャラ対テンプレート"
-          label="テンプレートを適用する"
-        />
+        <template v-if="isMatchup">
+          <v-autocomplete
+            v-model="v$.memo.fighterId.$model"
+            :error-messages="v$.memo.fighterId.$errors.map(e => e.$message)"
+            :items="fightersArray"
+            item-value="id"
+            item-title="name"
+            clearable
+            :menu-props="{ location: 'top', scrollStrategy: 'none' }"
+            name="相手ファイター"
+            label="相手ファイター"
+            hint="対策するファイターを選択してください"
+            variant="underlined"
+          />
+          <v-checkbox
+            v-model="applyTemplate"
+            name="キャラ対テンプレート"
+            label="テンプレートを適用する"
+          />
+        </template>
       </form>
     </v-card-text>
     <v-card-actions>
@@ -99,6 +101,11 @@ export default {
       applyTemplate: false,
       fightersArray: FIGHTERS_ARRAY
     };
+  },
+  computed: {
+    isMatchup() {
+      return (this.$route.name == "MatchupMemosIndex") ? true : false;
+    }
   },
   validations () {
     return {

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -60,7 +60,7 @@ import {
   maxLength,
   helpers
 } from '@vuelidate/validators';
-import { requiredMessage, maxLengthMessage } from '../../../constants/validationMessages';
+import { requiredMessage, maxLengthMessage } from '../../../constants/validationCustom';
 import { FIGHTERS_ARRAY } from '../../../constants/fightersArray';
 import TheAlert from '../../../components/TheAlert';
 

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -70,7 +70,7 @@ export default {
       },
       state: {
         type: String,
-        required: true
+        default: "local"
       }
     }
   },

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -47,7 +47,7 @@ import {
   maxLength,
   helpers
 } from '@vuelidate/validators';
-import { requiredMessage, maxLengthMessage } from '../../../constants/validationMessages';
+import { requiredMessage, maxLengthMessage } from '../../../constants/validationCustom';
 import { FIGHTERS_ARRAY } from '../../../constants/fightersArray';
 
 export default {

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -72,10 +72,6 @@ export default {
         type: String,
         required: true
       }
-    },
-    isMatchup: {
-      type: Boolean,
-      required: true
     }
   },
   emits: ["memo-submit"],
@@ -88,12 +84,15 @@ export default {
     return {
       memoStates: {
         local: "非公開",
-        shared: "公開中"
+        shared: "公開"
       },
       fightersArray: FIGHTERS_ARRAY
     };
   },
   computed: {
+    isMatchup() {
+      return (this.$route.name == "MatchupMemosEdit") ? true : false;
+    },
     memoStateLabel() {
       return this.memoStates[this.memo.state];
     }

--- a/app/frontend/pages/users/UsersLogin.vue
+++ b/app/frontend/pages/users/UsersLogin.vue
@@ -66,7 +66,7 @@ import {
   requiredMessage,
   emailMessage,
   minLengthMessage
-} from '../../constants/validationMessages';
+} from '../../constants/validationCustom';
 import {
   successLoginAlertStatus,
   failLoginAlertStatus,

--- a/app/frontend/pages/users/UsersLogin.vue
+++ b/app/frontend/pages/users/UsersLogin.vue
@@ -54,8 +54,8 @@
 </template>
 
 <script>
-import { useVuelidate } from '@vuelidate/core';
 import { mapActions } from 'vuex';
+import { useVuelidate } from '@vuelidate/core';
 import {
   required,
   email,

--- a/app/frontend/pages/users/UsersRegister.vue
+++ b/app/frontend/pages/users/UsersRegister.vue
@@ -72,8 +72,8 @@
 </template>
 
 <script>
-import { useVuelidate } from '@vuelidate/core';
 import { mapActions } from 'vuex';
+import { useVuelidate } from '@vuelidate/core';
 import {
   required,
   email,

--- a/app/frontend/pages/users/UsersRegister.vue
+++ b/app/frontend/pages/users/UsersRegister.vue
@@ -88,7 +88,7 @@ import {
   maxLengthMessage,
   minLengthMessage,
   sameAsMessage
-} from '../../constants/validationMessages';
+} from '../../constants/validationCustom';
 import {
   successRegisterAlertStatus,
   failRegisterAlertStatus,

--- a/app/frontend/plugins/imageCompression.js
+++ b/app/frontend/plugins/imageCompression.js
@@ -1,0 +1,22 @@
+import imageCompression from 'browser-image-compression';
+
+export default {
+  async getCompressImageFileAsync(file) {
+    const options = {
+      maxSizeMB: 0.5,
+      maxWidthOrHeight: 500
+    };
+    try {
+      return await imageCompression(file, options);
+    } catch (err) {
+      throw err;
+    }
+  },
+  async getDataUrlFromFile(file) {
+    try {
+      return await imageCompression.getDataUrlFromFile(file);
+    } catch (err) {
+      throw err;
+    }
+  }
+};

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -4,8 +4,8 @@ import store from '../store';
 import TopIndex from '../pages/static_pages/TopIndex';
 import UsersRegister from '../pages/users/UsersRegister';
 import UsersLogin from '../pages/users/UsersLogin';
-import MatchupFoldersIndex from '../pages/memos/matchup/MatchupFoldersIndex';
-import MatchupMemosIndex from '../pages/memos/matchup/MatchupMemosIndex';
+import FoldersIndex from '../pages/memos/common/FoldersIndex';
+import MemosIndex from '../pages/memos/common/MemosIndex';
 import MemosShow from '../pages/memos/common/MemosShow';
 import MemosEdit from '../pages/memos/common/MemosEdit';
 
@@ -33,13 +33,13 @@ const routes = [
   {
     path: "/matchup",
     name: "MatchupFoldersIndex",
-    component: MatchupFoldersIndex,
+    component: FoldersIndex,
     meta: { requiredAuth: true }
   },
   {
     path: "/matchup/:folderId/memos",
     name: "MatchupMemosIndex",
-    component: MatchupMemosIndex,
+    component: MemosIndex,
     meta: { requiredAuth: true }
   },
   {

--- a/app/frontend/store/modules/memos.js
+++ b/app/frontend/store/modules/memos.js
@@ -87,7 +87,11 @@ const actions = {
       });
   },
   createMemoBlock({ commit }, { memoId, memoBlockParams }) {
-    return axios.post(`memos/${memoId}/memo_blocks`, memoBlockParams)
+    return axios.post(`memos/${memoId}/memo_blocks`, memoBlockParams, {
+        headers: {
+          "Content-Type": "multipart/form-data"
+        }
+      })
       .then(res => {
         commit("addMemoBlock", res.data);
       });
@@ -100,7 +104,11 @@ const actions = {
       });
   },
   updateMemoBlock({ commit }, { memoId, memoBlockId, memoBlockParams }) {
-    return axios.patch(`memos/${memoId}/memo_blocks/${memoBlockId}`, memoBlockParams)
+    return axios.patch(`memos/${memoId}/memo_blocks/${memoBlockId}`, memoBlockParams, {
+        headers: {
+          "Content-Type": "multipart/form-data"
+        }
+      })
       .then(res => {
         commit("updateMemoBlock", res.data);
       });

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -1,0 +1,13 @@
+class Embed < ApplicationRecord
+  has_one :memo_block, as: :blockable, dependent: :destroy
+  has_one :memo, through: :memo_block
+
+  validates :subtitle, length: { maximum: 20 }
+  validates :identifier, length: { maximum: 200 }
+
+  enum embed_type: { youtube: 0, twitter: 1 }
+
+  def picture_url
+    nil
+  end
+end

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -5,7 +5,7 @@ class Embed < ApplicationRecord
   validates :subtitle, length: { maximum: 20 }
   validates :identifier, length: { maximum: 200 }
 
-  enum embed_type: { youtube: 0, twitter: 1 }
+  enum embed_type: { youtube: 0 }
 
   def picture_url
     nil

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,0 +1,8 @@
+class Image < ApplicationRecord
+  has_one :memo_block, as: :blockable, dependent: :destroy
+  has_one :memo, through: :memo_block
+
+  validates :subtitle, length: { maximum: 20 }
+
+  has_many_attached :pictures
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -3,6 +3,27 @@ class Image < ApplicationRecord
   has_one :memo, through: :memo_block
 
   validates :subtitle, length: { maximum: 20 }
+  validates :picture_width, numericality: { only_integer: true, greater_than_or_equal_to: 200, less_than_or_equal_to: 800 }
 
-  has_many_attached :pictures
+  has_one_attached :picture
+  attr_accessor :file
+
+  def parse_base64(file)
+    if file.present?
+      prefix = file[/(image|application)(\/.*)(?=\;)/]
+      type = prefix.sub(/(image|application)(\/)/, "")
+      data = Base64.decode64(file.sub(/data:#{prefix};base64,/, ""))
+      filename = "#{Time.zone.now.strftime('%Y%m%d%H%M%S%L')}.#{type}"
+      File.open("#{Rails.root}/tmp/#{filename}", 'wb') do |f|
+        f.write(data)
+      end
+      picture.detach if picture.attached?
+      picture.attach(io: File.open("#{Rails.root}/tmp/#{filename}"), filename: filename)
+      FileUtils.rm("#{Rails.root}/tmp/#{filename}")
+    end
+  end
+
+  def picture_url
+    picture.attached? ? Rails.application.routes.url_helpers.rails_blob_path(picture, only_path: true) : nil
+  end
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -7,5 +7,5 @@ class Memo < ApplicationRecord
 
   validates :title, presence: true, length: { maximum: 20 }
 
-  enum state: { local: 1, shared: 2 }
+  enum state: { local: 0, shared: 1  }
 end

--- a/app/models/memo_block.rb
+++ b/app/models/memo_block.rb
@@ -14,7 +14,7 @@ class MemoBlock < ApplicationRecord
 
   class << self
     def blockable_types
-      %w[Sentence]
+      %w[Sentence Image]
     end
 
     def valid_blockable_type?(type)
@@ -26,6 +26,8 @@ class MemoBlock < ApplicationRecord
     case type
     when 'Sentence'
       self.blockable = Sentence.create!
+    when 'Image'
+      self.blockable = Image.create!
     else
       raise "不正なブロックタイプです (#{type})"
     end

--- a/app/models/memo_block.rb
+++ b/app/models/memo_block.rb
@@ -14,7 +14,7 @@ class MemoBlock < ApplicationRecord
 
   class << self
     def blockable_types
-      %w[Sentence Image]
+      %w[Sentence Image Embed]
     end
 
     def valid_blockable_type?(type)
@@ -24,10 +24,12 @@ class MemoBlock < ApplicationRecord
 
   def create_blockable!(type)
     case type
-    when 'Sentence'
+    when "Sentence"
       self.blockable = Sentence.create!
-    when 'Image'
+    when "Image"
       self.blockable = Image.create!
+    when "Embed"
+      self.blockable = Embed.create!
     else
       raise "不正なブロックタイプです (#{type})"
     end

--- a/app/models/sentence.rb
+++ b/app/models/sentence.rb
@@ -3,5 +3,9 @@ class Sentence < ApplicationRecord
   has_one :memo, through: :memo_block
 
   validates :subtitle, length: { maximum: 20 }
-  validates :body, length: { maximum: 65536 }
+  validates :body, length: { maximum: 65535 }
+
+  def picture_url
+    nil
+  end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -34,7 +34,7 @@ Rails.application.configure do
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :amazon
+  config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -32,7 +32,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = "X-Accel-Redirect" # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
-  config.active_storage.service = :local
+  config.active_storage.service = :amazon
 
   # Mount Action Cable outside main process or domain.
   # config.action_cable.mount_path = nil

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,5 +15,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get '*path', to: 'top#index'
+  get '*path', to: 'top#index', constraints: lambda { |req|
+    req.path.exclude? 'rails/active_storage'
+  }
 end

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,12 +7,13 @@ local:
   root: <%= Rails.root.join("storage") %>
 
 # Use bin/rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-# amazon:
-#   service: S3
-#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-#   region: us-east-1
-#   bucket: your_own_bucket-<%= Rails.env %>
+amazon:
+  service: S3
+  access_key_id: <%= ENV["AWS_ACCESS_KEY_ID"] %>
+  secret_access_key: <%= ENV["AWS_SECRET_ACCESS_KEY"] %>
+  region: "us-east-1"
+  endpoint: "https://s3.us-east-1.amazonaws.com"
+  bucket: "smash-notice"
 
 # Remember not to checkin your GCS keyfile to a repository
 # google:

--- a/db/migrate/20231206091128_create_images.rb
+++ b/db/migrate/20231206091128_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :images do |t|
+      t.string :subtitle
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231206110649_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20231206110649_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,57 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    # Use Active Record's configured type for primary and foreign keys
+    primary_key_type, foreign_key_type = primary_and_foreign_key_types
+
+    create_table :active_storage_blobs, id: primary_key_type do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :key ], unique: true
+    end
+
+    create_table :active_storage_attachments, id: primary_key_type do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false, type: foreign_key_type
+      t.references :blob,     null: false, type: foreign_key_type
+
+      if connection.supports_datetime_with_precision?
+        t.datetime :created_at, precision: 6, null: false
+      else
+        t.datetime :created_at, null: false
+      end
+
+      t.index [ :record_type, :record_id, :name, :blob_id ], name: :index_active_storage_attachments_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records, id: primary_key_type do |t|
+      t.belongs_to :blob, null: false, index: false, type: foreign_key_type
+      t.string :variation_digest, null: false
+
+      t.index [ :blob_id, :variation_digest ], name: :index_active_storage_variant_records_uniqueness, unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+
+  private
+    def primary_and_foreign_key_types
+      config = Rails.configuration.generators
+      setting = config.options[config.orm][:primary_key_type]
+      primary_key_type = setting || :primary_key
+      foreign_key_type = setting || :bigint
+      [primary_key_type, foreign_key_type]
+    end
+end

--- a/db/migrate/20231208234949_add_picture_width_to_images.rb
+++ b/db/migrate/20231208234949_add_picture_width_to_images.rb
@@ -1,0 +1,5 @@
+class AddPictureWidthToImages < ActiveRecord::Migration[7.0]
+  def change
+    add_column :images, :picture_width, :integer, default: 500
+  end
+end

--- a/db/migrate/20231209213419_create_embeds.rb
+++ b/db/migrate/20231209213419_create_embeds.rb
@@ -1,0 +1,11 @@
+class CreateEmbeds < ActiveRecord::Migration[7.0]
+  def change
+    create_table :embeds do |t|
+      t.string :subtitle
+      t.integer :embed_type, default: 0, null: false
+      t.string :identifier
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231210095507_change_state_default_on_memos.rb
+++ b/db/migrate/20231210095507_change_state_default_on_memos.rb
@@ -1,0 +1,5 @@
+class ChangeStateDefaultOnMemos < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :memos, :state, from: 1, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_06_110649) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_08_234949) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -62,6 +62,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_06_110649) do
     t.string "subtitle"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "picture_width", default: 500
   end
 
   create_table "memo_blocks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,37 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_27_080743) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_06_110649) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.string "service_name", null: false
+    t.bigint "byte_size", null: false
+    t.string "checksum"
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "active_storage_variant_records", force: :cascade do |t|
+    t.bigint "blob_id", null: false
+    t.string "variation_digest", null: false
+    t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
 
   create_table "fighters", force: :cascade do |t|
     t.string "number"
@@ -28,6 +56,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_080743) do
     t.datetime "updated_at", null: false
     t.index ["fighter_id"], name: "index_folders_on_fighter_id"
     t.index ["user_id"], name: "index_folders_on_user_id"
+  end
+
+  create_table "images", force: :cascade do |t|
+    t.string "subtitle"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "memo_blocks", force: :cascade do |t|
@@ -73,6 +107,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_27_080743) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "folders", "fighters"
   add_foreign_key "folders", "users"
   add_foreign_key "memo_blocks", "memos"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_09_213419) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_10_095507) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,7 +87,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_09_213419) do
 
   create_table "memos", force: :cascade do |t|
     t.string "title", null: false
-    t.integer "state", default: 1
+    t.integer "state", default: 0
     t.string "type"
     t.bigint "user_id", null: false
     t.bigint "folder_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_08_234949) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_09_213419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_08_234949) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "embeds", force: :cascade do |t|
+    t.string "subtitle"
+    t.integer "embed_type", default: 0, null: false
+    t.string "identifier"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "fighters", force: :cascade do |t|

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@vuelidate/validators": "^2.0.4",
     "@vueup/vue-quill": "^1.2.0",
     "axios": "^1.6.0",
+    "browser-image-compression": "^2.0.2",
     "dayjs": "^1.11.10",
     "humps": "^2.0.1",
     "sanitize-html": "^2.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,13 @@ braces@^3.0.2:
   dependencies:
     fill-range "^7.0.1"
 
+browser-image-compression@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/browser-image-compression/-/browser-image-compression-2.0.2.tgz#4d5ef8882e9e471d6d923715ceb9034499d14eaa"
+  integrity sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==
+  dependencies:
+    uzip "0.20201231.0"
+
 call-bind@^1.0.2:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.5.tgz#6fa2b7845ce0ea49bf4d8b9ef64727a2c2e2e513"
@@ -1576,6 +1583,11 @@ util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uzip@0.20201231.0:
+  version "0.20201231.0"
+  resolved "https://registry.yarnpkg.com/uzip/-/uzip-0.20201231.0.tgz#9e64b065b9a8ebf26eb7583fe8e77e1d9a15ed14"
+  integrity sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==
 
 vite-plugin-environment@^1.1:
   version "1.1.3"


### PR DESCRIPTION
### 概要
- メモブロックの作成で画像とYouTubeの埋め込みを指定できるように追加

### 確認項目
- メモブロックに画像を選択でき、サイズの変更・プレビュー表示・画像の反映が成功すること
- メモブロックにYouTubeの埋め込みを選択でき、指定したURLによって正しく表示されること