### PR TITLE
攻略メモ機能の追加

### DIFF
--- a/app/controllers/api/folders_controller.rb
+++ b/app/controllers/api/folders_controller.rb
@@ -2,8 +2,8 @@ class Api::FoldersController < ApplicationController
   before_action :set_folder, only: %i[update destroy]
 
   def index
-    @folders = current_user.folders.where(type: params[:type])
-    render json: @folders, except: [:user_id, :created_at]
+    @folders = current_user.folders.where(type: params[:type]).order(updated_at: :desc)
+    render json: @folders, except: [:user_id, :created_at], methods: [:type]
   end
 
   def create

--- a/app/controllers/api/folders_controller.rb
+++ b/app/controllers/api/folders_controller.rb
@@ -8,7 +8,7 @@ class Api::FoldersController < ApplicationController
 
   def create
     @folder = current_user.folders.build(folder_params)
-    @folder.name = Fighter.find(@folder.fighter_id).name if @folder.name.blank?
+    @folder.name = @folder.fighter.name if @folder.name.blank?
 
     if @folder.save
       render json: @folder, except: [:user_id, :created_at]
@@ -19,7 +19,7 @@ class Api::FoldersController < ApplicationController
 
   def update
     @folder.assign_attributes(folder_params)
-    @folder.name = Fighter.find(@folder.fighter_id).name if @folder.name.blank?
+    @folder.name = @folder.fighter.name if @folder.name.blank?
 
     if @folder.save
       render json: @folder, except: [:user_id, :created_at]

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -9,7 +9,8 @@ class Api::MemosController < ApplicationController
   def create
     @memo = current_user.memos.build(memo_params)
     @memo.folder = @folder
-    @memo.title = Fighter.find(@memo.fighter_id).name if @memo.title.blank?
+    @memo.fighter = @folder.fighter
+    @memo.title = @memo.opponent.name if @memo.title.blank? && @memo.type == "MatchupMemo"
 
     if @memo.save
       render json: @memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}]
@@ -24,7 +25,7 @@ class Api::MemosController < ApplicationController
 
   def update
     @memo.assign_attributes(memo_params)
-    @memo.title = Fighter.find(@memo.fighter_id).name if @memo.title.blank?
+    @memo.title = @memo.opponent.name if @memo.title.blank? && @memo.type == "MatchupMemo"
 
     if @memo.save
       render json: @memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}]
@@ -49,6 +50,6 @@ class Api::MemosController < ApplicationController
   end
 
   def memo_params
-    params.require(:memo).permit(:title, :type, :fighter_id, :state)
+    params.require(:memo).permit(:title, :type, :opponent_id, :state)
   end
 end

--- a/app/frontend/app.vue
+++ b/app/frontend/app.vue
@@ -3,7 +3,7 @@
     <TheHeader />
     <v-main>
       <TheAlert />
-      <div class="mx-10 my-6">
+      <div class="mx-10 my-2">
         <router-view />
       </div>
     </v-main>

--- a/app/frontend/components/TheHeader.vue
+++ b/app/frontend/components/TheHeader.vue
@@ -80,11 +80,15 @@ export default {
   },
   methods: {
     ...mapActions("users", ["logoutUser"]),
-    ...mapActions("alert", ["displayAlert"]),
+    ...mapActions("alert", [
+      "displayAlert",
+      "cancelTransition"
+    ]),
     async handleLogout() {
       try {
         await this.logoutUser();
         this.displayAlert({ alertStatus: successLogoutAlertStatus });
+        if (this.$route.name == "TopIndex") this.cancelTransition();
         this.$router.push({ name: 'TopIndex' });
       } catch (err) {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });

--- a/app/frontend/components/TheSidebarList.vue
+++ b/app/frontend/components/TheSidebarList.vue
@@ -92,7 +92,7 @@ export default {
         strategy: {
           id: 1,
           title: "攻略メモ",
-          route: "Null",
+          route: "StrategyFoldersIndex",
           icon: mdiChartBar
         },
         matchup: {

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -204,10 +204,10 @@ export default {
   computed: {
     ...mapGetters("folders", ["folders"]),
     isMatchup() {
-      return (this.$route.name == "MatchupFoldersIndex") ? true : false;
+      return this.$route.name == "MatchupFoldersIndex" ? true : false;
     },
     pageInformation() {
-      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+      return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
     },
     sortedFolders() {
       return this.folders.slice().sort((a, b) => {

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -222,10 +222,10 @@ export default {
   computed: {
     ...mapGetters("memos", ["memoDetail"]),
     isMatchup() {
-      return (this.$route.name == "MatchupMemosEdit") ? true : false;
+      return this.$route.name == "MatchupMemosEdit" ? true : false;
     },
     pageInformation() {
-      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+      return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
     },
     memoId() {
       return this.$route.params.memoId;

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -190,7 +190,7 @@ export default {
       memoBlockDeleteDialog: false,
       memo: {
         title: "",
-        fighterId: null,
+        opponentId: null,
         state: ""
       },
       memoBlockDefault: {

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -70,6 +70,7 @@
     >
       <MemoEditForm
         :memo="memo"
+        :form-title-hint="pageInformation.formTitleHint"
         @memo-submit="handleMemoUpdate"
       />
       <router-link
@@ -180,10 +181,12 @@ export default {
   data() {
     return {
       pageInformationMatchup: {
-        showRouteName: "MatchupMemosShow"
+        showRouteName: "MatchupMemosShow",
+        formTitleHint: "未入力の場合、下記の相手ファイター名が設定されます"
       },
       pageInformationStrategy: {
-        showRouteName: "StrategyMemosShow"
+        showRouteName: "StrategyMemosShow",
+        formTitleHint: "メモのタイトルを入力してください"
       },
       memoBlockCreateDialog: false,
       memoBlockEditDialog: false,

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -313,7 +313,7 @@ export default {
     async handleMemoUpdate(memo) {
       try {
         await this.updateMemo(memo);
-        this.$router.go({path: this.$router.currentRoute.path, force: true});
+        this.$router.go({ name: this.$route.name, force: true });
       } catch (error) {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });
       }

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -140,6 +140,7 @@
     >
       <MemoCreateFormDialog
         :memo="memo"
+        :form-title-hint="pageInformation.formTitleHint"
         @close-dialog="handleCloseMemoDialog"
         @memo-submit="handleMemoCreate"
       />
@@ -194,13 +195,15 @@ export default {
         memoCategory: "キャラ対メモ",
         memoType: "MatchupMemo",
         pathPrefix: "matchup",
-        editRouteName: "MatchupMemosEdit"
+        editRouteName: "MatchupMemosEdit",
+        formTitleHint: "未入力の場合、下記の相手ファイター名が設定されます"
       },
       pageInformationStrategy: {
         memoCategory: "攻略メモ",
         memoType: "StrategyMemo",
         pathPrefix: "strategy",
-        editRouteName: "StrategyMemosEdit"
+        editRouteName: "StrategyMemosEdit",
+        formTitleHint: "メモのタイトルを入力してください"
       },
       memoDefault: {
         id: null,
@@ -254,6 +257,7 @@ export default {
     ]),
     handleOpenMemoCreateDialog() {
       this.memo = Object.assign({}, this.memoDefault);
+      if (!this.isMatchup) this.memo.opponentId = 1;
       this.memoCreateDialog = true;
     },
     handleOpenMemoDeleteDialog(memo) {

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -220,10 +220,10 @@ export default {
       "memos"
     ]),
     isMatchup() {
-      return (this.$route.name == "MatchupMemosIndex") ? true : false;
+      return this.$route.name == "MatchupMemosIndex" ? true : false;
     },
     pageInformation() {
-      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+      return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
     },
     folderId() {
       return this.$route.params.folderId;

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -205,7 +205,7 @@ export default {
       memoDefault: {
         id: null,
         title: "",
-        fighterId: null
+        opponentId: null
       },
       memo: {},
       memoCreateDialog: false,

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -172,10 +172,10 @@ export default {
   computed: {
     ...mapGetters("memos", ["memoDetail"]),
     isMatchup() {
-      return (this.$route.name == "MatchupMemosShow") ? true : false;
+      return this.$route.name == "MatchupMemosShow" ? true : false;
     },
     pageInformation() {
-      return (this.isMatchup) ? this.pageInformationMatchup : this.pageInformationStrategy;
+      return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
     },
     memoId() {
       return this.$route.params.memoId;

--- a/app/frontend/pages/memos/components/EmbedYoutube.vue
+++ b/app/frontend/pages/memos/components/EmbedYoutube.vue
@@ -19,7 +19,7 @@ export default {
   data() {
     return {
       embedYoutubeUrl : ""
-    }
+    };
   },
   computed: {
     playerWidth() {
@@ -43,7 +43,7 @@ export default {
       params.forEach((param) => {
         param.replace("t=", "amp;start=");
         result = result + param + "&";
-      })
+      });
 
       result = "https://www.youtube.com/embed/" + result.slice(0, -1);
       return result;

--- a/app/frontend/pages/memos/components/FolderFormDialog.vue
+++ b/app/frontend/pages/memos/components/FolderFormDialog.vue
@@ -9,7 +9,7 @@
         <v-text-field
           v-model="v$.folder.name.$model"
           :error-messages="v$.folder.name.$errors.map(e => e.$message)"
-          :counter="20"
+          :counter="30"
           name="フォルダ名"
           label="フォルダ名"
           hint="未入力の場合、下記の使用ファイター名が設定されます"
@@ -98,7 +98,7 @@ export default {
     return {
       folder: {
         name: { 
-          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         fighterId: {
           required: helpers.withMessage(requiredMessage("使用ファイター"), required)

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -29,7 +29,7 @@
           <v-text-field
             v-model="v$.sentence.subtitle.$model"
             :error-messages="v$.sentence.subtitle.$errors.map(e => e.$message)"
-            :counter="20"
+            :counter="30"
             name="見出し"
             label="見出し"
             hint="未入力にすることも可能です"
@@ -50,7 +50,7 @@
           <v-text-field
             v-model="v$.image.subtitle.$model"
             :error-messages="v$.image.subtitle.$errors.map(e => e.$message)"
-            :counter="20"
+            :counter="30"
             name="見出し"
             label="見出し"
             hint="未入力にすることも可能です"
@@ -93,7 +93,7 @@
           <v-text-field
             v-model="v$.embed.subtitle.$model"
             :error-messages="v$.embed.subtitle.$errors.map(e => e.$message)"
-            :counter="20"
+            :counter="30"
             name="見出し"
             label="見出し"
             hint="未入力にすることも可能です"
@@ -278,7 +278,7 @@ export default {
       },
       sentence: {
         subtitle: { 
-          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         body: {
           maxLength: helpers.withMessage("保存できる文字数を超えています", maxLength(65535))
@@ -286,7 +286,7 @@ export default {
       },
       image: {
         subtitle: { 
-          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         file: {
           image: helpers.withMessage("無効なファイル形式です", image)
@@ -295,7 +295,7 @@ export default {
       },
       embed: {
         subtitle: { 
-          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         embedType: {},
         identifier: {

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -12,7 +12,7 @@
           :counter="30"
           name="タイトル"
           label="タイトル"
-          hint="未入力の場合、下記の相手ファイター名が設定されます"
+          :hint="formTitleHint"
           variant="underlined"
         />
         <template v-if="isMatchup">
@@ -56,7 +56,7 @@
 <script>
 import { useVuelidate } from '@vuelidate/core';
 import {
-  required,
+  requiredIf,
   maxLength,
   helpers
 } from '@vuelidate/validators';
@@ -85,6 +85,10 @@ export default {
         type: Number,
         required: true
       }
+    },
+    formTitleHint: {
+      type: String,
+      required: true
     }
   },
   emits: [
@@ -110,11 +114,12 @@ export default {
   validations () {
     return {
       memo: {
-        title: { 
+        title: {
+          required: helpers.withMessage(requiredMessage("タイトル"), requiredIf(!this.isMatchup)),
           maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         opponentId: {
-          required: helpers.withMessage(requiredMessage("相手ファイター"), required)
+          required: helpers.withMessage(requiredMessage("相手ファイター"), requiredIf(this.isMatchup))
         }
       }
     };

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -104,7 +104,7 @@ export default {
   },
   computed: {
     isMatchup() {
-      return (this.$route.name == "MatchupMemosIndex") ? true : false;
+      return this.$route.name == "MatchupMemosIndex" ? true : false;
     }
   },
   validations () {

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -17,8 +17,8 @@
         />
         <template v-if="isMatchup">
           <v-autocomplete
-            v-model="v$.memo.fighterId.$model"
-            :error-messages="v$.memo.fighterId.$errors.map(e => e.$message)"
+            v-model="v$.memo.opponentId.$model"
+            :error-messages="v$.memo.opponentId.$errors.map(e => e.$message)"
             :items="fightersArray"
             item-value="id"
             item-title="name"
@@ -81,7 +81,7 @@ export default {
         type: String,
         required: true
       },
-      fighterId: {
+      opponentId: {
         type: Number,
         required: true
       }
@@ -113,7 +113,7 @@ export default {
         title: { 
           maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
-        fighterId: {
+        opponentId: {
           required: helpers.withMessage(requiredMessage("相手ファイター"), required)
         }
       }

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -9,7 +9,7 @@
         <v-text-field
           v-model="v$.memo.title.$model"
           :error-messages="v$.memo.title.$errors.map(e => e.$message)"
-          :counter="20"
+          :counter="30"
           name="タイトル"
           label="タイトル"
           hint="未入力の場合、下記の相手ファイター名が設定されます"
@@ -111,7 +111,7 @@ export default {
     return {
       memo: {
         title: { 
-          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         fighterId: {
           required: helpers.withMessage(requiredMessage("相手ファイター"), required)

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -10,8 +10,8 @@
     />
     <template v-if="isMatchup">
       <v-autocomplete
-        v-model="v$.memo.fighterId.$model"
-        :error-messages="v$.memo.fighterId.$errors.map(e => e.$message)"
+        v-model="v$.memo.opponentId.$model"
+        :error-messages="v$.memo.opponentId.$errors.map(e => e.$message)"
         :items="fightersArray"
         item-value="id"
         item-title="name"
@@ -64,7 +64,7 @@ export default {
         type: String,
         required: true
       },
-      fighterId: {
+      opponentId: {
         type: Number,
         required: true
       },
@@ -103,7 +103,7 @@ export default {
         title: { 
           maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
-        fighterId: {
+        opponentId: {
           required: helpers.withMessage(requiredMessage("相手ファイター"), required)
         },
         state: {}

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -6,6 +6,7 @@
       :counter="30"
       name="タイトル"
       label="タイトル"
+      :hint="formTitleHint"
       variant="underlined"
     />
     <template v-if="isMatchup">
@@ -43,7 +44,7 @@
 <script>
 import { useVuelidate } from '@vuelidate/core';
 import {
-  required,
+  requiredIf,
   maxLength,
   helpers
 } from '@vuelidate/validators';
@@ -72,6 +73,10 @@ export default {
         type: String,
         default: "local"
       }
+    },
+    formTitleHint: {
+      type: String,
+      required: true
     }
   },
   emits: ["memo-submit"],
@@ -101,10 +106,11 @@ export default {
     return {
       memo: {
         title: { 
+          required: helpers.withMessage(requiredMessage("タイトル"), requiredIf(!this.isMatchup)),
           maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         opponentId: {
-          required: helpers.withMessage(requiredMessage("相手ファイター"), required)
+          required: helpers.withMessage(requiredMessage("相手ファイター"), requiredIf(this.isMatchup))
         },
         state: {}
       }

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -91,7 +91,7 @@ export default {
   },
   computed: {
     isMatchup() {
-      return (this.$route.name == "MatchupMemosEdit") ? true : false;
+      return this.$route.name == "MatchupMemosEdit" ? true : false;
     },
     memoStateLabel() {
       return this.memoStates[this.memo.state];

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -3,7 +3,7 @@
     <v-text-field
       v-model="v$.memo.title.$model"
       :error-messages="v$.memo.title.$errors.map(e => e.$message)"
-      :counter="20"
+      :counter="30"
       name="タイトル"
       label="タイトル"
       variant="underlined"
@@ -101,7 +101,7 @@ export default {
     return {
       memo: {
         title: { 
-          maxLength: helpers.withMessage(maxLengthMessage(20), maxLength(20))
+          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         fighterId: {
           required: helpers.withMessage(requiredMessage("相手ファイター"), required)

--- a/app/frontend/pages/static_pages/TopIndex.vue
+++ b/app/frontend/pages/static_pages/TopIndex.vue
@@ -1,15 +1,18 @@
 <template>
   <div class="text-md-h3 text-h4 font-weight-bold">
-    スマブラ専用メモツール
+    <span class="d-inline-block">スマブラ専用</span>
+    <span class="d-inline-block">メモツール</span>
   </div>
 
   <div class="my-6" />
 
-  <div class="text-body-1 font-weight-bold">
-    SmashNoticeは「大乱闘スマッシュブラザーズSPECIAL」の攻略メモを整理・共有できるメモツールです。
-  </div>
+  <template v-if="displayDescription">
+    <div class="text-body-1 font-weight-bold">
+      SmashNoticeは「大乱闘スマッシュブラザーズSPECIAL」の攻略メモを整理・共有できるメモツールです。
+    </div>
 
-  <div class="my-8" />
+    <div class="my-8" />
+  </template>
 
   <template v-if="!authUser">
     <div class="text-body-1 font-weight-bold">
@@ -49,6 +52,7 @@
       </v-btn>
     </div>
   </template>
+
   <template v-else>
     <div class="text-body-1 font-weight-bold">
       <router-link
@@ -60,7 +64,33 @@
       では自分の使用しているファイターに関する立ち回りやコンボなどをまとめることができます。
     </div>
 
-    <div class="my-8" />
+    <template v-if="strategyFolders.length">
+      <v-card
+        max-width="500"
+        class="mt-2"
+      >
+        <v-card-title>
+          攻略メモフォルダ一覧
+        </v-card-title>
+        <v-card-text>
+          <v-list max-height="120">
+            <template
+              v-for="folderItem in strategyFolders"
+              :key="folderItem.id"
+            >
+                <v-list-item
+                  :title="folderItem.name"
+                  :subtitle="dateFormat(folderItem.updatedAt)"
+                  :to="{ path: `/strategy/${folderItem.id}/memos` }"
+                  :prepend-icon="mdiFolder"
+                />
+            </template>
+          </v-list>
+        </v-card-text>
+      </v-card>
+    </template>
+
+    <div class="my-6" />
 
     <div class="text-body-1 font-weight-bold">
       <router-link
@@ -71,6 +101,32 @@
       </router-link>
       では相手ファイターの対策をファイターごとにまとめることができます。
 
+      <template v-if="matchupFolders.length">
+        <v-card
+          max-width="500"
+          class="mt-2"
+        >
+          <v-card-title>
+            キャラ対メモフォルダ一覧
+          </v-card-title>
+          <v-card-text>
+            <v-list max-height="120">
+              <template
+                v-for="folderItem in matchupFolders"
+                :key="folderItem.id"
+              >
+                  <v-list-item
+                    :title="folderItem.name"
+                    :subtitle="dateFormat(folderItem.updatedAt)"
+                    :to="{ path: `/matchup/${folderItem.id}/memos` }"
+                    :prepend-icon="mdiFolder"
+                  />
+              </template>
+            </v-list>
+          </v-card-text>
+        </v-card>
+      </template>
+
       <div class="my-4" />
 
       テンプレート機能を活用して、統一されたフォーマットで整理することも可能です。
@@ -79,12 +135,43 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapActions } from 'vuex';
+import { mdiFolder } from '@mdi/js';
+import dayjs from 'dayjs';
 
 export default {
   name: "TopIndex",
-  computed: {
-    ...mapGetters("users", ["authUser"])
+  data() {
+    return {
+      mdiFolder
+    }
   },
+  computed: {
+    ...mapGetters("users", ["authUser"]),
+    ...mapGetters("folders", ["folders"]),
+    displayDescription() {
+      if (!this.authUser) return true;
+      if (!this.folders.length) return true;
+      return false;
+    },
+    matchupFolders() {
+      return this.folders.filter(folder => {
+        return folder.type == "MatchupFolder";
+      })
+    },
+    strategyFolders() {
+      return this.folders.filter(folder => {
+        return folder.type == "StrategyFolder";
+      })
+    }
+  },
+  created() {
+    if (this.authUser) this.$store.dispatch("folders/fetchFolders", ["MatchupFolder", "StrategyFolder"]);
+  },
+  methods: {
+    dateFormat(date) {
+      return dayjs(date).format("YYYY-MM-DD");
+    }
+  }
 };
 </script>

--- a/app/frontend/pages/static_pages/TopIndex.vue
+++ b/app/frontend/pages/static_pages/TopIndex.vue
@@ -52,7 +52,7 @@
   <template v-else>
     <div class="text-body-1 font-weight-bold">
       <router-link
-        :to="{ name: 'Null' }"
+        :to="{ name: 'StrategyFoldersIndex' }"
         class="text-decoration-underline"
       >
         攻略メモ

--- a/app/frontend/plugins/axios.js
+++ b/app/frontend/plugins/axios.js
@@ -13,7 +13,7 @@ if (localStorage.auth_token) {
 
 axiosInstance.interceptors.request.use((req) => {
   // axiosでリクエストを送るたびに、アラートを初期化
-  store.dispatch("alert/closeAlert");
+  if (req.method === "post" || req.method === "patch") store.dispatch("alert/closeAlert");
 
   // リクエストのデータの各Keyをスネークケース化
   req.data = humps.decamelizeKeys(req.data);

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -37,8 +37,20 @@ const routes = [
     meta: { requiredAuth: true }
   },
   {
+    path: "/strategy",
+    name: "StrategyFoldersIndex",
+    component: FoldersIndex,
+    meta: { requiredAuth: true }
+  },
+  {
     path: "/matchup/:folderId/memos",
     name: "MatchupMemosIndex",
+    component: MemosIndex,
+    meta: { requiredAuth: true }
+  },
+  {
+    path: "/strategy/:folderId/memos",
+    name: "StrategyMemosIndex",
     component: MemosIndex,
     meta: { requiredAuth: true }
   },
@@ -49,8 +61,20 @@ const routes = [
     meta: { requiredAuth: true }
   },
   {
+    path: "/Strategy/memos/:memoId",
+    name: "StrategyMemosShow",
+    component: MemosShow,
+    meta: { requiredAuth: true }
+  },
+  {
     path: "/matchup/memos/:memoId/edit",
     name: "MatchupMemosEdit",
+    component: MemosEdit,
+    meta: { requiredAuth: true }
+  },
+  {
+    path: "/strategy/memos/:memoId/edit",
+    name: "StrategyMemosEdit",
     component: MemosEdit,
     meta: { requiredAuth: true }
   },

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -2,7 +2,7 @@ class Embed < ApplicationRecord
   has_one :memo_block, as: :blockable, dependent: :destroy
   has_one :memo, through: :memo_block
 
-  validates :subtitle, length: { maximum: 20 }
+  validates :subtitle, length: { maximum: 30 }
   validates :identifier, length: { maximum: 200 }
 
   enum embed_type: { youtube: 0 }

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -4,5 +4,5 @@ class Folder < ApplicationRecord
 
   has_many :memos, dependent: :destroy
 
-  validates :name, presence: true, length: { maximum: 20 }
+  validates :name, presence: true, length: { maximum: 30 }
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,7 +2,7 @@ class Image < ApplicationRecord
   has_one :memo_block, as: :blockable, dependent: :destroy
   has_one :memo, through: :memo_block
 
-  validates :subtitle, length: { maximum: 20 }
+  validates :subtitle, length: { maximum: 30 }
   validates :picture_width, numericality: { only_integer: true, greater_than_or_equal_to: 200, less_than_or_equal_to: 800 }
 
   has_one_attached :picture

--- a/app/models/matchup_memo.rb
+++ b/app/models/matchup_memo.rb
@@ -1,3 +1,2 @@
 class MatchupMemo < Memo
-  belongs_to :fighter
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -4,8 +4,10 @@ class Memo < ApplicationRecord
 
   has_many :memo_blocks, -> { order(level: :desc) }, inverse_of: :memo, dependent: :destroy
   has_many :sentences, through: :memo_blocks, source: :blockable, source_type: 'Sentence'
+  has_many :images, through: :memo_blocks, source: :blockable, source_type: 'Image'
+  has_many :embeds, through: :memo_blocks, source: :blockable, source_type: 'Embed'
 
-  validates :title, presence: true, length: { maximum: 20 }
+  validates :title, presence: true, length: { maximum: 30 }
 
-  enum state: { local: 0, shared: 1  }
+  enum state: { local: 0, shared: 1 }
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -1,6 +1,8 @@
 class Memo < ApplicationRecord
   belongs_to :user
   belongs_to :folder
+  belongs_to :fighter
+  belongs_to :opponent, class_name: "Fighter", foreign_key: :opponent_id
 
   has_many :memo_blocks, -> { order(level: :desc) }, inverse_of: :memo, dependent: :destroy
   has_many :sentences, through: :memo_blocks, source: :blockable, source_type: 'Sentence'

--- a/app/models/sentence.rb
+++ b/app/models/sentence.rb
@@ -2,7 +2,7 @@ class Sentence < ApplicationRecord
   has_one :memo_block, as: :blockable, dependent: :destroy
   has_one :memo, through: :memo_block
 
-  validates :subtitle, length: { maximum: 20 }
+  validates :subtitle, length: { maximum: 30 }
   validates :body, length: { maximum: 65535 }
 
   def picture_url

--- a/db/migrate/20231211062226_add_opponent_to_memos.rb
+++ b/db/migrate/20231211062226_add_opponent_to_memos.rb
@@ -1,0 +1,5 @@
+class AddOpponentToMemos < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :memos, :opponent, foreign_key: { to_table: :fighters }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_10_095507) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_11_062226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -94,8 +94,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_10_095507) do
     t.bigint "fighter_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "opponent_id"
     t.index ["fighter_id"], name: "index_memos_on_fighter_id"
     t.index ["folder_id"], name: "index_memos_on_folder_id"
+    t.index ["opponent_id"], name: "index_memos_on_opponent_id"
     t.index ["user_id"], name: "index_memos_on_user_id"
   end
 
@@ -122,6 +124,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_10_095507) do
   add_foreign_key "folders", "users"
   add_foreign_key "memo_blocks", "memos"
   add_foreign_key "memos", "fighters"
+  add_foreign_key "memos", "fighters", column: "opponent_id"
   add_foreign_key "memos", "folders"
   add_foreign_key "memos", "users"
 end


### PR DESCRIPTION
### 概要
- 攻略メモの一覧・作成・編集・削除・詳細の機能やページの追加

### 確認項目
- 攻略メモに対して行った変更などが正しく反映されること
- 以下のキャラ対メモにしかない要素が機能・表示されていないこと
  - フォルダ詳細画面のテンプレート編集ボタン
  - キャラ対メモ作成・編集時のタイトルのバリデーションと相手ファイターの選択フォーム