### PR TITLE
テンプレート編集機能の追加

### DIFF
--- a/app/controllers/api/memo_blocks_controller.rb
+++ b/app/controllers/api/memo_blocks_controller.rb
@@ -12,7 +12,7 @@ class Api::MemoBlocksController < ApplicationController
         return head :bad_request
       end
 
-      @memo_block.create_blockable!(blockable_type)
+      @memo_block.create_blockable!(blockable_type, blockable_params)
 
       if @memo_block.invalid?(:insert)
         return head :bad_request
@@ -21,14 +21,7 @@ class Api::MemoBlocksController < ApplicationController
       @memo_block.insert_and_save!
     end
 
-    @blockable = @memo_block.blockable
-
-    if @blockable.update(blockable_params)
-      @blockable.parse_base64(image_params[:file]) if params.key?(:image)
-      render json: @memo_block, include: [{blockable: {methods: :picture_url}}]
-    else
-      render json: @blockable.errors.full_messages, status: :bad_request
-    end
+    render json: @memo_block, include: [{blockable: {methods: :picture_url}}]
   end
 
   def update

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -3,7 +3,7 @@ class Api::MemosController < ApplicationController
   before_action :set_memo, only: %i[show update destroy]
 
   def index
-    render json: @folder, include: [{memos: {except: [:user_id, :created_at]}}]
+    render json: @folder, methods: [:memos_excluded_template]
   end
 
   def create

--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -1,5 +1,5 @@
 class Api::MemosController < ApplicationController
-  before_action :set_folder, only: %i[index create]
+  before_action :set_folder, only: %i[index create template]
   before_action :set_memo, only: %i[show update destroy]
 
   def index
@@ -37,6 +37,11 @@ class Api::MemosController < ApplicationController
   def destroy
     @memo.destroy!
     render json: @memo
+  end
+
+  def template
+    @template_memo = @folder.template_memo
+    render json: @template_memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}]
   end
 
   private

--- a/app/frontend/constants/validationCustom.js
+++ b/app/frontend/constants/validationCustom.js
@@ -2,7 +2,7 @@ import { helpers } from '@vuelidate/validators';
 
 export const image = (value) => {
   const pattern = /^data:image\/(jpeg|jpg|png);base64,/;
-  return value.match(pattern) || !helpers.req(value);
+  return pattern.test(value) || !helpers.req(value);
 };
 
 // バリデーションのエラーメッセージ

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -1,167 +1,169 @@
 <template>
-  <div class="text-md-h3 text-h4 font-weight-bold">
-    {{ pageInformation.pageTitle }}
-  </div>
+  <template v-if="isDataReceived">
+    <div class="text-md-h3 text-h4 font-weight-bold">
+      {{ pageInformation.pageTitle }}
+    </div>
 
-  <div class="my-6" />
+    <div class="my-6" />
 
-  <v-row>
-    <v-col
-      cols="12"
-      sm="10"
-      md="8"
-      lg="8"
-      xl="8"
-    >
-      <template v-if="folders.length">
-        <div class="d-flex">
-          <span class="text-h5">
-            フォルダ一覧
-          </span>
-          <v-spacer />
-          <v-btn
-            color="teal-accent-4"
-            class="mb-2 mr-2"
-            @click="handleOpenFolderCreateDialog"
-          >
-            フォルダの追加
-          </v-btn>
-        </div>
-        <v-list lines="two">
-          <template
-            v-for="folderItem in sortedFolders"
-            :key="folderItem.id"
-          >
-            <div class="list-item-folder">
-              <v-list-item
-                :title="folderItem.name"
-                :subtitle="dateFormat(folderItem.updatedAt)"
-                :to="{ path: `/${pageInformation.pathPrefix}/${folderItem.id}/memos` }"
-                :prepend-icon="mdiFolder"
-              />
-              <v-btn
-                icon
-                density="compact"
-                variant="plain"
-                class="list-item-folder-info"
-              >
-                <v-icon :icon="mdiInformationOutline" />
-                <v-menu activator="parent">
-                  <v-list density="compact">
-                    <v-list-item @click="handleOpenFolderEditDialog(folderItem)">
-                      <v-list-item-title>
-                        <span>
-                          フォルダを編集する
-                        </span>
-                      </v-list-item-title>
-                    </v-list-item>
-                    <v-list-item @click="handleOpenFolderDeleteDialog(folderItem)">
-                      <v-list-item-title>
-                        <span class="text-error">
-                          フォルダを削除する
-                        </span>
-                      </v-list-item-title>
-                    </v-list-item>
-                  </v-list>
-                </v-menu>
-              </v-btn>
-            </div>
-          </template>
-        </v-list>
-      </template>
+    <v-row>
+      <v-col
+        cols="12"
+        sm="10"
+        md="8"
+        lg="8"
+        xl="8"
+      >
+        <template v-if="folders.length">
+          <div class="d-flex">
+            <span class="text-h5">
+              フォルダ一覧
+            </span>
+            <v-spacer />
+            <v-btn
+              color="teal-accent-4"
+              class="mb-2 mr-2"
+              @click="handleOpenFolderCreateDialog"
+            >
+              フォルダの追加
+            </v-btn>
+          </div>
+          <v-list lines="two">
+            <template
+              v-for="folderItem in sortedFolders"
+              :key="folderItem.id"
+            >
+              <div class="list-item-folder">
+                <v-list-item
+                  :title="folderItem.name"
+                  :subtitle="dateFormat(folderItem.updatedAt)"
+                  :to="{ path: `/${pageInformation.pathPrefix}/${folderItem.id}/memos` }"
+                  :prepend-icon="mdiFolder"
+                />
+                <v-btn
+                  icon
+                  density="compact"
+                  variant="plain"
+                  class="list-item-folder-info"
+                >
+                  <v-icon :icon="mdiInformationOutline" />
+                  <v-menu activator="parent">
+                    <v-list density="compact">
+                      <v-list-item @click="handleOpenFolderEditDialog(folderItem)">
+                        <v-list-item-title>
+                          <span>
+                            フォルダを編集する
+                          </span>
+                        </v-list-item-title>
+                      </v-list-item>
+                      <v-list-item @click="handleOpenFolderDeleteDialog(folderItem)">
+                        <v-list-item-title>
+                          <span class="text-error">
+                            フォルダを削除する
+                          </span>
+                        </v-list-item-title>
+                      </v-list-item>
+                    </v-list>
+                  </v-menu>
+                </v-btn>
+              </div>
+            </template>
+          </v-list>
+        </template>
 
-      <template v-else>
-        <div class="text-body-1 font-weight-bold">
-          まだ、フォルダがありません。
+        <template v-else>
+          <div class="text-body-1 font-weight-bold">
+            まだ、フォルダがありません。
+
+            <div class="my-8" />
+
+            フォルダの追加から自分の使用ファイターを選択して、フォルダを追加しましょう。
+          </div>
 
           <div class="my-8" />
 
-          フォルダの追加から自分の使用ファイターを選択して、フォルダを追加しましょう。
-        </div>
+          <v-layout>
+            <v-btn
+              class="mx-auto"
+              color="teal-accent-4"
+              @click="handleOpenFolderCreateDialog"
+            >
+              フォルダの追加
+            </v-btn>
+          </v-layout>
+        </template>
+      </v-col>
+    </v-row>
 
-        <div class="my-8" />
-
-        <v-layout>
-          <v-btn
-            class="mx-auto"
-            color="teal-accent-4"
-            @click="handleOpenFolderCreateDialog"
-          >
+    <div class="justify-center">
+      <v-dialog
+        v-model="folderCreateDialog"
+        width="700px"
+      >
+        <FolderFormDialog
+          :folder="folder"
+          @close-dialog="handleCloseFolderDialog"
+          @folder-submit="handleFolderCreate"
+        >
+          <template #title>
             フォルダの追加
-          </v-btn>
-        </v-layout>
-      </template>
-    </v-col>
-  </v-row>
+          </template>
+          <template #submit>
+            作成
+          </template>
+        </FolderFormDialog>
+      </v-dialog>
+    </div>
 
-  <div class="justify-center">
-    <v-dialog
-      v-model="folderCreateDialog"
-      width="700px"
-    >
-      <FolderFormDialog
-        :folder="folder"
-        @close-dialog="handleCloseFolderDialog"
-        @folder-submit="handleFolderCreate"
+    <div class="justify-center">
+      <v-dialog
+        v-model="folderEditDialog"
+        width="700px"
       >
-        <template #title>
-          フォルダの追加
-        </template>
-        <template #submit>
-          作成
-        </template>
-      </FolderFormDialog>
-    </v-dialog>
-  </div>
-
-  <div class="justify-center">
-    <v-dialog
-      v-model="folderEditDialog"
-      width="700px"
-    >
-      <FolderFormDialog
-        :folder="folder"
-        @close-dialog="handleCloseFolderDialog"
-        @folder-submit="handleFolderUpdate"
+        <FolderFormDialog
+          :folder="folder"
+          @close-dialog="handleCloseFolderDialog"
+          @folder-submit="handleFolderUpdate"
+        >
+          <template #title>
+            フォルダの編集
+          </template>
+          <template #submit>
+            更新
+          </template>
+        </FolderFormDialog>
+      </v-dialog>
+    </div>
+    
+    <div class="justify-center">
+      <v-dialog
+        v-model="folderDeleteDialog"
+        width="500px"
       >
-        <template #title>
-          フォルダの編集
-        </template>
-        <template #submit>
-          更新
-        </template>
-      </FolderFormDialog>
-    </v-dialog>
-  </div>
-  
-  <div class="justify-center">
-    <v-dialog
-      v-model="folderDeleteDialog"
-      width="500px"
-    >
-      <v-card>
-        <v-card-title class="ma-2">
-          <span class="text-h5 font-weight-bold">フォルダの削除</span>
-        </v-card-title>
-        <v-card-text>
-          「{{ folder.name }}」フォルダを削除してもよろしいですか？
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn @click="handleCloseFolderDialog">
-            キャンセル
-          </v-btn>
-          <v-btn
-            class="mr-4"
-            color="error"
-            @click="handleFolderDelete"
-          >
-            削除
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </div>
+        <v-card>
+          <v-card-title class="ma-2">
+            <span class="text-h5 font-weight-bold">フォルダの削除</span>
+          </v-card-title>
+          <v-card-text>
+            「{{ folder.name }}」フォルダを削除してもよろしいですか？
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn @click="handleCloseFolderDialog">
+              キャンセル
+            </v-btn>
+            <v-btn
+              class="mr-4"
+              color="error"
+              @click="handleFolderDelete"
+            >
+              削除
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </div>
+  </template>
 </template>
 
 <script>
@@ -202,7 +204,10 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("folders", ["folders"]),
+    ...mapGetters("folders", [
+      "isDataReceived",
+      "folders"
+    ]),
     isMatchup() {
       return this.$route.name == "MatchupFoldersIndex";
     },

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -204,7 +204,7 @@ export default {
   computed: {
     ...mapGetters("folders", ["folders"]),
     isMatchup() {
-      return this.$route.name == "MatchupFoldersIndex" ? true : false;
+      return this.$route.name == "MatchupFoldersIndex";
     },
     pageInformation() {
       return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
@@ -218,6 +218,9 @@ export default {
     }
   },
   created() {
+    this.$store.dispatch("folders/fetchFolders", this.pageInformation.folderType);
+  },
+  updated() {
     this.$store.dispatch("folders/fetchFolders", this.pageInformation.folderType);
   },
   methods: {

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -218,13 +218,14 @@ export default {
     }
   },
   created() {
-    this.$store.dispatch("folders/fetchFolders", this.pageInformation.folderType);
+    this.fetchFolders(this.pageInformation.folderType);
   },
   updated() {
-    this.$store.dispatch("folders/fetchFolders", this.pageInformation.folderType);
+    this.fetchFolders(this.pageInformation.folderType);
   },
   methods: {
     ...mapActions("folders", [
+      "fetchFolders",
       "createFolder",
       "updateFolder",
       "deleteFolder"

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -225,7 +225,7 @@ export default {
   computed: {
     ...mapGetters("memos", ["memoDetail"]),
     isMatchup() {
-      return this.$route.name == "MatchupMemosEdit" ? true : false;
+      return this.$route.name == "MatchupMemosEdit";
     },
     pageInformation() {
       return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -12,46 +12,64 @@
       lg="8"
       xl="8"
     >
-      <template
-        v-for="memoBlockItem in memoDetail.memoBlocks"
-        :key="memoBlockItem.id"
-      >
-        <v-card
-          :title="memoBlockItem.blockable.subtitle"
-          class="mb-2"
+      <template v-if="memoDetail.memoBlocks.length">
+        <template
+          v-for="memoBlockItem in memoDetail.memoBlocks"
+          :key="memoBlockItem.id"
         >
-          <v-card-text>
-            <template v-if="memoBlockItem.blockableType == 'Sentence'">
-              <p v-html="sanitizeHtml(memoBlockItem.blockable.body)" />
-            </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Image'">
-              <v-img
-                :src="memoBlockItem.blockable.pictureUrl"
-                :width="memoBlockItem.blockable.pictureWidth"
-              />
-            </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Embed'">
-              <EmbedYoutube
-                :youtube-url="memoBlockItem.blockable.identifier"
-              />
-            </template>
-          </v-card-text>
-          <v-card-actions>
-            <v-spacer />
-            <v-btn
-              color="error"
-              @click="handleOpenMemoBlockDeleteDialog(memoBlockItem)"
-            >
-              削除
-            </v-btn>
-            <v-btn
-              class="mr-4"
-              @click="handleOpenMemoBlockEditDialog(memoBlockItem)"
-            >
-              編集
-            </v-btn>
-          </v-card-actions>
-        </v-card>
+          <v-card
+            :title="memoBlockItem.blockable.subtitle"
+            class="mb-2"
+          >
+            <v-card-text>
+              <template v-if="memoBlockItem.blockableType == 'Sentence'">
+                <p v-html="sanitizeHtml(memoBlockItem.blockable.body)" />
+              </template>
+              <template v-else-if="memoBlockItem.blockableType == 'Image'">
+                <v-img
+                  :src="memoBlockItem.blockable.pictureUrl"
+                  :width="memoBlockItem.blockable.pictureWidth"
+                />
+              </template>
+              <template v-else-if="memoBlockItem.blockableType == 'Embed'">
+                <EmbedYoutube
+                  :youtube-url="memoBlockItem.blockable.identifier"
+                />
+              </template>
+            </v-card-text>
+            <v-card-actions>
+              <v-spacer />
+              <v-btn
+                color="error"
+                @click="handleOpenMemoBlockDeleteDialog(memoBlockItem)"
+              >
+                削除
+              </v-btn>
+              <v-btn
+                class="mr-4"
+                @click="handleOpenMemoBlockEditDialog(memoBlockItem)"
+              >
+                編集
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </template>
+      </template>
+      <template v-else>
+        <template v-if="isTemplate">
+          <div class="text-body-1 font-weight-bold">
+            <span class="d-inline-block">キャラ対メモの作成時に「テンプレートを適用する」にチェックを入れることで、</span>
+            <span class="d-inline-block">テンプレートに設定した内容が自動的に追加されます。</span>
+          </div>
+        </template>
+        <template v-else>
+          <div class="text-body-1 font-weight-bold">
+            まだ、メモブロックがありません。
+            メモブロックを追加しましょう。
+          </div>
+        </template>
+
+          <div class="my-8" />
       </template>
       <v-btn
         block
@@ -62,29 +80,33 @@
         メモブロックを追加する
       </v-btn>
     </v-col>
-    <v-col
-      cols="12"
-      md="4"
-      lg="4"
-      xl="4"
-    >
-      <MemoEditForm
-        :memo="memo"
-        :form-title-hint="pageInformation.formTitleHint"
-        @memo-submit="handleMemoUpdate"
-      />
-      <router-link
-        :to="{ name: pageInformation.showRouteName, params: { memoId: memoDetail.id } }"
+
+    <template v-if="!isTemplate">
+      <v-col
+        cols="12"
+        md="4"
+        lg="4"
+        xl="4"
       >
-        <v-btn
-          block
-          class="mt-4"
+        <MemoEditForm
+          :memo="memo"
+          :form-title-hint="pageInformation.formTitleHint"
+          @memo-submit="handleMemoUpdate"
+        />
+        <router-link
+          :to="{ name: pageInformation.showRouteName, params: { memoId: memoDetail.id } }"
         >
-          メモ詳細画面へ進む
-        </v-btn>
-      </router-link>
-    </v-col>
+          <v-btn
+            block
+            class="mt-4"
+          >
+            メモ詳細画面へ進む
+          </v-btn>
+        </router-link>
+      </v-col>
+    </template>
   </v-row>
+
   <div class="justify-center">
     <v-dialog
       v-model="memoBlockCreateDialog"
@@ -180,6 +202,10 @@ export default {
   },
   data() {
     return {
+      pageInformationTemplate: {
+        showRouteName: "",
+        formTitleHint: ""
+      },
       pageInformationMatchup: {
         showRouteName: "MatchupMemosShow",
         formTitleHint: "未入力の場合、下記の相手ファイター名が設定されます"
@@ -224,31 +250,49 @@ export default {
   },
   computed: {
     ...mapGetters("memos", ["memoDetail"]),
+    isTemplate() {
+      return this.$route.name == "MatchupTemplate";
+    },
     isMatchup() {
       return this.$route.name == "MatchupMemosEdit";
     },
     pageInformation() {
-      return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
+      return this.isTemplate ? pageInformationTemplate
+        : this.isMatchup ? this.pageInformationMatchup
+        : this.pageInformationStrategy;
     },
     memoId() {
-      return this.$route.params.memoId;
+      return this.isTemplate ? this.memoDetail.id : this.$route.params.memoId;
     }
   },
   created() {
-    this.$store.dispatch("memos/fetchMemoDetail", this.$route.params.memoId)
-      .then(() => {
-        this.memo = Object.assign({}, this.memoDetail);
-      })
-      .catch(() => {
-        this.displayAlert({ alertStatus: serverErrorAlertStatus });
-        this.$router.push({ name: "TopIndex" });
-      });
+    if (this.isTemplate) {
+      this.fetchTemplate(this.$route.params.folderId)
+        .then(() => {
+          this.memo = Object.assign({}, this.memoDetail);
+        })
+        .catch(() => {
+          this.displayAlert({ alertStatus: serverErrorAlertStatus });
+          this.$router.push({ name: "TopIndex" });
+        });
+    } else {
+      this.fetchMemoDetail(this.memoId)
+        .then(() => {
+          this.memo = Object.assign({}, this.memoDetail);
+        })
+        .catch(() => {
+          this.displayAlert({ alertStatus: serverErrorAlertStatus });
+          this.$router.push({ name: "TopIndex" });
+        });
+    }
   },
   updated() {
     this.memo = Object.assign({}, this.memoDetail);
   },
   methods: {
     ...mapActions("memos", [
+      "fetchTemplate",
+      "fetchMemoDetail",
       "createMemoBlock",
       "updateMemo",
       "updateMemoBlock",

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -1,188 +1,190 @@
 <template>
-  <div class="text-md-h3 text-h4 font-weight-bold">
-    {{ memoDetail.title }}
-  </div>
+  <template v-if="isDataReceived">
+    <div class="text-md-h3 text-h4 font-weight-bold">
+      {{ memoDetail.title }}
+    </div>
 
-  <div class="my-6" />
+    <div class="my-6" />
 
-  <v-row>
-    <v-col
-      cols="12"
-      md="8"
-      lg="8"
-      xl="8"
-    >
-      <template v-if="memoDetail.memoBlocks.length">
-        <template
-          v-for="memoBlockItem in memoDetail.memoBlocks"
-          :key="memoBlockItem.id"
-        >
-          <v-card
-            :title="memoBlockItem.blockable.subtitle"
-            class="mb-2"
-          >
-            <v-card-text>
-              <template v-if="memoBlockItem.blockableType == 'Sentence'">
-                <p v-html="sanitizeHtml(memoBlockItem.blockable.body)" />
-              </template>
-              <template v-else-if="memoBlockItem.blockableType == 'Image'">
-                <v-img
-                  :src="memoBlockItem.blockable.pictureUrl"
-                  :width="memoBlockItem.blockable.pictureWidth"
-                />
-              </template>
-              <template v-else-if="memoBlockItem.blockableType == 'Embed'">
-                <EmbedYoutube
-                  :youtube-url="memoBlockItem.blockable.identifier"
-                />
-              </template>
-            </v-card-text>
-            <v-card-actions>
-              <v-spacer />
-              <v-btn
-                color="error"
-                @click="handleOpenMemoBlockDeleteDialog(memoBlockItem)"
-              >
-                削除
-              </v-btn>
-              <v-btn
-                class="mr-4"
-                @click="handleOpenMemoBlockEditDialog(memoBlockItem)"
-              >
-                編集
-              </v-btn>
-            </v-card-actions>
-          </v-card>
-        </template>
-      </template>
-      <template v-else>
-        <template v-if="isTemplate">
-          <div class="text-body-1 font-weight-bold">
-            <span class="d-inline-block">キャラ対メモの作成時に「テンプレートを適用する」にチェックを入れることで、</span>
-            <span class="d-inline-block">テンプレートに設定した内容が自動的に追加されます。</span>
-          </div>
-        </template>
-        <template v-else>
-          <div class="text-body-1 font-weight-bold">
-            まだ、メモブロックがありません。
-            メモブロックを追加しましょう。
-          </div>
-        </template>
-
-          <div class="my-8" />
-      </template>
-      <v-btn
-        block
-        color="teal-accent-4"
-        class="mt-4"
-        @click="handleOpenMemoBlockCreateDialog"
-      >
-        メモブロックを追加する
-      </v-btn>
-    </v-col>
-
-    <template v-if="!isTemplate">
+    <v-row>
       <v-col
         cols="12"
-        md="4"
-        lg="4"
-        xl="4"
+        md="8"
+        lg="8"
+        xl="8"
       >
-        <MemoEditForm
-          :memo="memo"
-          :form-title-hint="pageInformation.formTitleHint"
-          @memo-submit="handleMemoUpdate"
-        />
-        <router-link
-          :to="{ name: pageInformation.showRouteName, params: { memoId: memoDetail.id } }"
+        <template v-if="memoDetail.memoBlocks.length">
+          <template
+            v-for="memoBlockItem in memoDetail.memoBlocks"
+            :key="memoBlockItem.id"
+          >
+            <v-card
+              :title="memoBlockItem.blockable.subtitle"
+              class="mb-2"
+            >
+              <v-card-text>
+                <template v-if="memoBlockItem.blockableType == 'Sentence'">
+                  <p v-html="sanitizeHtml(memoBlockItem.blockable.body)" />
+                </template>
+                <template v-else-if="memoBlockItem.blockableType == 'Image'">
+                  <v-img
+                    :src="memoBlockItem.blockable.pictureUrl"
+                    :width="memoBlockItem.blockable.pictureWidth"
+                  />
+                </template>
+                <template v-else-if="memoBlockItem.blockableType == 'Embed'">
+                  <EmbedYoutube
+                    :youtube-url="memoBlockItem.blockable.identifier"
+                  />
+                </template>
+              </v-card-text>
+              <v-card-actions>
+                <v-spacer />
+                <v-btn
+                  color="error"
+                  @click="handleOpenMemoBlockDeleteDialog(memoBlockItem)"
+                >
+                  削除
+                </v-btn>
+                <v-btn
+                  class="mr-4"
+                  @click="handleOpenMemoBlockEditDialog(memoBlockItem)"
+                >
+                  編集
+                </v-btn>
+              </v-card-actions>
+            </v-card>
+          </template>
+        </template>
+        <template v-else>
+          <template v-if="isTemplate">
+            <div class="text-body-1 font-weight-bold">
+              <span class="d-inline-block">キャラ対メモの作成時に「テンプレートを適用する」にチェックを入れることで、</span>
+              <span class="d-inline-block">テンプレートに設定した内容が自動的に追加されます。</span>
+            </div>
+          </template>
+          <template v-else>
+            <div class="text-body-1 font-weight-bold">
+              まだ、メモブロックがありません。
+              メモブロックを追加しましょう。
+            </div>
+          </template>
+
+            <div class="my-8" />
+        </template>
+        <v-btn
+          block
+          color="teal-accent-4"
+          class="mt-4"
+          @click="handleOpenMemoBlockCreateDialog"
         >
-          <v-btn
-            block
-            class="mt-4"
-          >
-            メモ詳細画面へ進む
-          </v-btn>
-        </router-link>
+          メモブロックを追加する
+        </v-btn>
       </v-col>
-    </template>
-  </v-row>
 
-  <div class="justify-center">
-    <v-dialog
-      v-model="memoBlockCreateDialog"
-      width="700px"
-    >
-      <MemoBlockFormDialog
-        :memo-block="memoBlock"
-        :sentence="sentence"
-        :image="image"
-        :embed="embed"
-        :is-edit="false"
-        @close-dialog="handleCloseMemoBlockDialog"
-        @memoblock-submit="handleMemoBlockCreate"
-      >
-        <template #title>
-          メモブロックの追加
-        </template>
-        <template #submit>
-          作成
-        </template>
-      </MemoBlockFormDialog>
-    </v-dialog>
-  </div>
-
-  <div class="justify-center">
-    <v-dialog
-      v-model="memoBlockEditDialog"
-      width="700px"
-    >
-      <MemoBlockFormDialog
-        :memo-block="memoBlock"
-        :sentence="sentence"
-        :image="image"
-        :embed="embed"
-        :is-edit="true"
-        @close-dialog="handleCloseMemoBlockDialog"
-        @memoblock-submit="handleMemoBlockUpdate"
-      >
-        <template #title>
-          メモブロックの編集
-        </template>
-        <template #submit>
-          更新
-        </template>
-      </MemoBlockFormDialog>
-    </v-dialog>
-  </div>
-
-  <div class="justify-center">
-    <v-dialog
-      v-model="memoBlockDeleteDialog"
-      width="500px"
-    >
-      <v-card>
-        <v-card-title class="ma-2">
-          <span class="text-h5 font-weight-bold">メモブロックの削除</span>
-        </v-card-title>
-        <v-card-text>
-          メモブロックを削除してもよろしいですか？
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn @click="handleCloseMemoBlockDialog">
-            キャンセル
-          </v-btn>
-          <v-btn
-            class="mr-4"
-            color="error"
-            @click="handleMemoBlockDelete"
+      <template v-if="!isTemplate">
+        <v-col
+          cols="12"
+          md="4"
+          lg="4"
+          xl="4"
+        >
+          <MemoEditForm
+            :memo="memo"
+            :form-title-hint="pageInformation.formTitleHint"
+            @memo-submit="handleMemoUpdate"
+          />
+          <router-link
+            :to="{ name: pageInformation.showRouteName, params: { memoId: memoDetail.id } }"
           >
-            削除
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </div>
+            <v-btn
+              block
+              class="mt-4"
+            >
+              メモ詳細画面へ進む
+            </v-btn>
+          </router-link>
+        </v-col>
+      </template>
+    </v-row>
+
+    <div class="justify-center">
+      <v-dialog
+        v-model="memoBlockCreateDialog"
+        width="700px"
+      >
+        <MemoBlockFormDialog
+          :memo-block="memoBlock"
+          :sentence="sentence"
+          :image="image"
+          :embed="embed"
+          :is-edit="false"
+          @close-dialog="handleCloseMemoBlockDialog"
+          @memoblock-submit="handleMemoBlockCreate"
+        >
+          <template #title>
+            メモブロックの追加
+          </template>
+          <template #submit>
+            作成
+          </template>
+        </MemoBlockFormDialog>
+      </v-dialog>
+    </div>
+
+    <div class="justify-center">
+      <v-dialog
+        v-model="memoBlockEditDialog"
+        width="700px"
+      >
+        <MemoBlockFormDialog
+          :memo-block="memoBlock"
+          :sentence="sentence"
+          :image="image"
+          :embed="embed"
+          :is-edit="true"
+          @close-dialog="handleCloseMemoBlockDialog"
+          @memoblock-submit="handleMemoBlockUpdate"
+        >
+          <template #title>
+            メモブロックの編集
+          </template>
+          <template #submit>
+            更新
+          </template>
+        </MemoBlockFormDialog>
+      </v-dialog>
+    </div>
+
+    <div class="justify-center">
+      <v-dialog
+        v-model="memoBlockDeleteDialog"
+        width="500px"
+      >
+        <v-card>
+          <v-card-title class="ma-2">
+            <span class="text-h5 font-weight-bold">メモブロックの削除</span>
+          </v-card-title>
+          <v-card-text>
+            メモブロックを削除してもよろしいですか？
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn @click="handleCloseMemoBlockDialog">
+              キャンセル
+            </v-btn>
+            <v-btn
+              class="mr-4"
+              color="error"
+              @click="handleMemoBlockDelete"
+            >
+              削除
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </div>
+  </template>
 </template>
 
 <script>
@@ -249,7 +251,10 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("memos", ["memoDetail"]),
+    ...mapGetters("memos", [
+      "isDataReceived",
+      "memoDetail"
+    ]),
     isTemplate() {
       return this.$route.name == "MatchupTemplate";
     },

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -1,184 +1,186 @@
 <template>
-  <div class="text-md-h3 text-h4 font-weight-bold">
-    {{ folder.name }}
-  </div>
+  <template v-if="isDataReceived">
+    <div class="text-md-h3 text-h4 font-weight-bold">
+      {{ folder.name }}
+    </div>
 
-  <div class="my-6" />
+    <div class="my-6" />
 
-  <v-row>
-    <v-col
-      cols="12"
-      sm="10"
-      md="8"
-      lg="8"
-      xl="8"
-    >
-      <template v-if="memos.length">
-        <div class="d-flex align-end">
-          <span class="text-h5 mb-5">
-            メモ一覧
-          </span>
-          <v-spacer />
-          <div>
-            <template v-if="isMatchup">
-              <div>
-                <router-link
-                  :to="{ name: 'MatchupTemplate', params: { folderId: folder.id } }"
-                >
+    <v-row>
+      <v-col
+        cols="12"
+        sm="10"
+        md="8"
+        lg="8"
+        xl="8"
+      >
+        <template v-if="memos.length">
+          <div class="d-flex align-end">
+            <span class="text-h5 mb-5">
+              メモ一覧
+            </span>
+            <v-spacer />
+            <div>
+              <template v-if="isMatchup">
+                <div>
+                  <router-link
+                    :to="{ name: 'MatchupTemplate', params: { folderId: folder.id } }"
+                  >
+                    <v-btn
+                      size="small"
+                      color="teal-accent-4"
+                      class="mb-2"
+                    >
+                      テンプレートの編集
+                    </v-btn>
+                  </router-link>
+                </div>
+                <div>
                   <v-btn
                     size="small"
                     color="teal-accent-4"
-                    class="mb-2"
+                    @click="handleOpenMemoCreateDialog"
                   >
-                    テンプレートの編集
+                    メモの作成
                   </v-btn>
-                </router-link>
-              </div>
-              <div>
+                </div>
+              </template>
+              <template v-else>
                 <v-btn
-                  size="small"
                   color="teal-accent-4"
+                  class="mb-2 mr-2"
                   @click="handleOpenMemoCreateDialog"
                 >
                   メモの作成
                 </v-btn>
+              </template>
+            </div>
+          </div>
+          <v-list lines="two">
+            <template
+              v-for="memoItem in sortedMemos"
+              :key="memoItem.id"
+            >
+              <div class="list-item-memo">
+                <v-list-item
+                  :title="memoItem.title"
+                  :subtitle="dateFormat(memoItem.updatedAt)"
+                  :to="{ path: `/${pageInformation.pathPrefix}/memos/${memoItem.id}` }"
+                  :prepend-icon="mdiFile"
+                />
+                <v-btn
+                  icon
+                  density="compact"
+                  variant="plain"
+                  class="list-item-memo-info"
+                >
+                  <v-icon :icon="mdiInformationOutline" />
+                  <v-menu activator="parent">
+                    <v-list density="compact">
+                      <v-list-item
+                        :to="{ name: pageInformation.editRouteName, params: { memoId: memoItem.id } }"
+                      >
+                        <v-list-item-title>
+                          <span>
+                            メモを編集する
+                          </span>
+                        </v-list-item-title>
+                      </v-list-item>
+                      <v-list-item @click="handleOpenMemoDeleteDialog(memoItem)">
+                        <v-list-item-title>
+                          <span class="text-error">
+                            メモを削除する
+                          </span>
+                        </v-list-item-title>
+                      </v-list-item>
+                    </v-list>
+                  </v-menu>
+                </v-btn>
               </div>
             </template>
-            <template v-else>
+          </v-list>
+        </template>
+
+        <template v-else>
+          <div class="text-body-1 font-weight-bold">
+            まだ、メモがありません。
+            メモの作成から{{ pageInformation.memoCategory }}を追加しましょう。
+
+            <template v-if="isMatchup">
+              <div class="my-8" />
+
+              テンプレート機能を使うと、キャラ対メモの作成時にテンプレートに設定した内容が自動的に追加されます。
+            </template>
+          </div>
+
+          <div class="my-8" />
+
+          <v-layout>
+            <div class="mx-auto">
               <v-btn
+                class="mr-8 mb-2"
                 color="teal-accent-4"
-                class="mb-2 mr-2"
                 @click="handleOpenMemoCreateDialog"
               >
                 メモの作成
               </v-btn>
-            </template>
-          </div>
-        </div>
-        <v-list lines="two">
-          <template
-            v-for="memoItem in sortedMemos"
-            :key="memoItem.id"
-          >
-            <div class="list-item-memo">
-              <v-list-item
-                :title="memoItem.title"
-                :subtitle="dateFormat(memoItem.updatedAt)"
-                :to="{ path: `/${pageInformation.pathPrefix}/memos/${memoItem.id}` }"
-                :prepend-icon="mdiFile"
-              />
-              <v-btn
-                icon
-                density="compact"
-                variant="plain"
-                class="list-item-memo-info"
-              >
-                <v-icon :icon="mdiInformationOutline" />
-                <v-menu activator="parent">
-                  <v-list density="compact">
-                    <v-list-item
-                      :to="{ name: pageInformation.editRouteName, params: { memoId: memoItem.id } }"
-                    >
-                      <v-list-item-title>
-                        <span>
-                          メモを編集する
-                        </span>
-                      </v-list-item-title>
-                    </v-list-item>
-                    <v-list-item @click="handleOpenMemoDeleteDialog(memoItem)">
-                      <v-list-item-title>
-                        <span class="text-error">
-                          メモを削除する
-                        </span>
-                      </v-list-item-title>
-                    </v-list-item>
-                  </v-list>
-                </v-menu>
-              </v-btn>
+              <template v-if="isMatchup">
+                <v-btn
+                  class="mb-2"
+                  color="teal-accent-4"
+                >
+                  テンプレートの編集
+                </v-btn>
+              </template>
             </div>
-          </template>
-        </v-list>
-      </template>
+          </v-layout>
+        </template>
+      </v-col>
+    </v-row>
 
-      <template v-else>
-        <div class="text-body-1 font-weight-bold">
-          まだ、メモがありません。
-          メモの作成から{{ pageInformation.memoCategory }}を追加しましょう。
-
-          <template v-if="isMatchup">
-            <div class="my-8" />
-
-            テンプレート機能を使うと、キャラ対メモの作成時にテンプレートに設定した内容が自動的に追加されます。
-          </template>
-        </div>
-
-        <div class="my-8" />
-
-        <v-layout>
-          <div class="mx-auto">
-            <v-btn
-              class="mr-8 mb-2"
-              color="teal-accent-4"
-              @click="handleOpenMemoCreateDialog"
-            >
-              メモの作成
+    <div class="justify-center">
+      <v-dialog
+        v-model="memoCreateDialog"
+        width="700px"
+      >
+        <MemoCreateFormDialog
+          :memo="memo"
+          :form-title-hint="pageInformation.formTitleHint"
+          @close-dialog="handleCloseMemoDialog"
+          @memo-submit="handleMemoCreate"
+        />
+      </v-dialog>
+    </div>
+    
+    <div class="justify-center">
+      <v-dialog
+        v-model="memoDeleteDialog"
+        width="500px"
+      >
+        <v-card>
+          <v-card-title class="ma-2">
+            <span class="text-h5 font-weight-bold">メモの削除</span>
+          </v-card-title>
+          <v-card-text>
+            「{{ memo.title }}」メモを削除してもよろしいですか？
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn @click="handleCloseMemoDialog">
+              キャンセル
             </v-btn>
-            <template v-if="isMatchup">
-              <v-btn
-                class="mb-2"
-                color="teal-accent-4"
-              >
-                テンプレートの編集
-              </v-btn>
-            </template>
-          </div>
-        </v-layout>
-      </template>
-    </v-col>
-  </v-row>
-
-  <div class="justify-center">
-    <v-dialog
-      v-model="memoCreateDialog"
-      width="700px"
-    >
-      <MemoCreateFormDialog
-        :memo="memo"
-        :form-title-hint="pageInformation.formTitleHint"
-        @close-dialog="handleCloseMemoDialog"
-        @memo-submit="handleMemoCreate"
-      />
-    </v-dialog>
-  </div>
-  
-  <div class="justify-center">
-    <v-dialog
-      v-model="memoDeleteDialog"
-      width="500px"
-    >
-      <v-card>
-        <v-card-title class="ma-2">
-          <span class="text-h5 font-weight-bold">メモの削除</span>
-        </v-card-title>
-        <v-card-text>
-          「{{ memo.title }}」メモを削除してもよろしいですか？
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn @click="handleCloseMemoDialog">
-            キャンセル
-          </v-btn>
-          <v-btn
-            class="mr-4"
-            color="error"
-            @click="handleMemoDelete"
-          >
-            削除
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </div>
+            <v-btn
+              class="mr-4"
+              color="error"
+              @click="handleMemoDelete"
+            >
+              削除
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </div>
+  </template>
 </template>
 
 <script>
@@ -223,6 +225,7 @@ export default {
   },
   computed: {
     ...mapGetters("memos", [
+      "isDataReceived",
       "folder",
       "memos"
     ]),

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="text-md-h3 text-h4 font-weight-bold">
-    {{ folderName }}
+    {{ folder.name }}
   </div>
 
   <div class="my-6" />
@@ -22,13 +22,17 @@
           <div>
             <template v-if="isMatchup">
               <div>
-                <v-btn
-                  size="small"
-                  color="teal-accent-4"
-                  class="mb-2"
+                <router-link
+                  :to="{ name: 'MatchupTemplate', params: { folderId: folder.id } }"
                 >
-                  テンプレートの編集
-                </v-btn>
+                  <v-btn
+                    size="small"
+                    color="teal-accent-4"
+                    class="mb-2"
+                  >
+                    テンプレートの編集
+                  </v-btn>
+                </router-link>
               </div>
               <div>
                 <v-btn
@@ -219,7 +223,7 @@ export default {
   },
   computed: {
     ...mapGetters("memos", [
-      "folderName",
+      "folder",
       "memos"
     ]),
     isMatchup() {
@@ -240,7 +244,7 @@ export default {
     }
   },
   created() {
-    this.$store.dispatch("memos/fetchMemos", this.folderId)
+    this.fetchMemos(this.folderId)
       .catch(() => {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });
         this.$router.push({ name: "TopIndex" });
@@ -248,6 +252,7 @@ export default {
   },
   methods: {
     ...mapActions("memos", [
+      "fetchMemos",
       "createMemo",
       "deleteMemo"
     ]),

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -223,7 +223,7 @@ export default {
       "memos"
     ]),
     isMatchup() {
-      return this.$route.name == "MatchupMemosIndex" ? true : false;
+      return this.$route.name == "MatchupMemosIndex";
     },
     pageInformation() {
       return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -1,148 +1,150 @@
 <template>
-  <div class="text-md-h3 text-h4 font-weight-bold">
-    {{ memoDetail.title }}
-  </div>
+  <template v-if="isDataReceived">
+    <div class="text-md-h3 text-h4 font-weight-bold">
+      {{ memoDetail.title }}
+    </div>
 
-  <div class="my-6" />
+    <div class="my-6" />
 
-  <v-row>
-    <v-col
-      cols="12"
-      md="8"
-      lg="8"
-      xl="8"
-    >
-      <template v-if="memoDetail.memoBlocks.length">
-        <div style="min-height: 55vh;">
-          <template
-            v-for="memoBlockItem in memoDetail.memoBlocks"
-            :key="memoBlockItem.id"
-          >
-            <template v-if="!(memoBlockItem.blockable.subtitle == '')">
-              <div class="text-md-h5 text-h6 mb-4">
-                {{ memoBlockItem.blockable.subtitle }}
-              </div>
-            </template>
-            <template v-if="memoBlockItem.blockableType == 'Sentence'">
-              <div
-                class="ml-2 mt-n2 mb-4 sentence-body"
-                v-html="sanitizeHtml(memoBlockItem.blockable.body)"
-              />
-            </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Image'">
-              <v-img
-                :src="memoBlockItem.blockable.pictureUrl"
-                :width="memoBlockItem.blockable.pictureWidth"
-                class="ml-2 mt-n2 mb-4"
-              />
-            </template>
-            <template v-else-if="memoBlockItem.blockableType == 'Embed'">
-              <div class="ml-2 mt-n2 mb-4">
-                <EmbedYoutube
-                  :youtube-url="memoBlockItem.blockable.identifier"
-                />
-              </div>
-            </template>
-          </template>
-        </div>
-        <div class="d-flex flex-row justify-end mt-8">
-          <v-btn
-            color="error"
-            @click="handleOpenMemoDeleteDialog"
-          >
-            削除
-          </v-btn>
-          <router-link
-            :to="{ name: pageInformation.editRouteName, params: { memoId: memoDetail.id }}"
-          >
-            <v-btn
-              color="teal-accent-4"
-              class="mx-4"
-            >
-              編集
-            </v-btn>
-          </router-link>
-        </div>
-      </template>
-      <template v-else>
-        <div class="text-body-1 font-weight-bold">
-          まだ、メモブロックがありません。
-          メモの編集からメモブロックを追加しましょう。
-        </div>
-
-        <div class="my-8" />
-
-        <v-layout>
-          <router-link
-            :to="{ name: pageInformation.editRouteName, params: { memoId: memoDetail.id }}"
-            class="mx-auto"
-          >
-            <v-btn
-              color="teal-accent-4"
-            >
-              メモの編集
-            </v-btn>
-          </router-link>
-        </v-layout>
-      </template>
-    </v-col>
-    <template v-if="$vuetify.display.mdAndUp">
+    <v-row>
       <v-col
-        md="4"
-        lg="4"
-        xl="4"
+        cols="12"
+        md="8"
+        lg="8"
+        xl="8"
       >
-        <router-link
-          :to="{ name: pageInformation.editRouteName, params: { memoId: memoDetail.id }}"
+        <template v-if="memoDetail.memoBlocks.length">
+          <div style="min-height: 55vh;">
+            <template
+              v-for="memoBlockItem in memoDetail.memoBlocks"
+              :key="memoBlockItem.id"
+            >
+              <template v-if="!(memoBlockItem.blockable.subtitle == '')">
+                <div class="text-md-h5 text-h6 mb-4">
+                  {{ memoBlockItem.blockable.subtitle }}
+                </div>
+              </template>
+              <template v-if="memoBlockItem.blockableType == 'Sentence'">
+                <div
+                  class="ml-2 mt-n2 mb-4 sentence-body"
+                  v-html="sanitizeHtml(memoBlockItem.blockable.body)"
+                />
+              </template>
+              <template v-else-if="memoBlockItem.blockableType == 'Image'">
+                <v-img
+                  :src="memoBlockItem.blockable.pictureUrl"
+                  :width="memoBlockItem.blockable.pictureWidth"
+                  class="ml-2 mt-n2 mb-4"
+                />
+              </template>
+              <template v-else-if="memoBlockItem.blockableType == 'Embed'">
+                <div class="ml-2 mt-n2 mb-4">
+                  <EmbedYoutube
+                    :youtube-url="memoBlockItem.blockable.identifier"
+                  />
+                </div>
+              </template>
+            </template>
+          </div>
+          <div class="d-flex flex-row justify-end mt-8">
+            <v-btn
+              color="error"
+              @click="handleOpenMemoDeleteDialog"
+            >
+              削除
+            </v-btn>
+            <router-link
+              :to="{ name: pageInformation.editRouteName, params: { memoId: memoDetail.id }}"
+            >
+              <v-btn
+                color="teal-accent-4"
+                class="mx-4"
+              >
+                編集
+              </v-btn>
+            </router-link>
+          </div>
+        </template>
+        <template v-else>
+          <div class="text-body-1 font-weight-bold">
+            まだ、メモブロックがありません。
+            メモの編集からメモブロックを追加しましょう。
+          </div>
+
+          <div class="my-8" />
+
+          <v-layout>
+            <router-link
+              :to="{ name: pageInformation.editRouteName, params: { memoId: memoDetail.id }}"
+              class="mx-auto"
+            >
+              <v-btn
+                color="teal-accent-4"
+              >
+                メモの編集
+              </v-btn>
+            </router-link>
+          </v-layout>
+        </template>
+      </v-col>
+      <template v-if="$vuetify.display.mdAndUp">
+        <v-col
+          md="4"
+          lg="4"
+          xl="4"
         >
+          <router-link
+            :to="{ name: pageInformation.editRouteName, params: { memoId: memoDetail.id }}"
+          >
+            <v-btn
+              block
+              color="teal-accent-4"
+              class="mt-4"
+            >
+              メモを編集する
+            </v-btn>
+          </router-link>
           <v-btn
             block
-            color="teal-accent-4"
-            class="mt-4"
-          >
-            メモを編集する
-          </v-btn>
-        </router-link>
-        <v-btn
-          block
-          color="error"
-          class="mt-4"
-          @click="handleOpenMemoDeleteDialog"
-        >
-          メモを削除する
-        </v-btn>
-      </v-col>
-    </template>
-  </v-row>
-
-  <div class="justify-center">
-    <v-dialog
-      v-model="memoDeleteDialog"
-      width="500px"
-    >
-      <v-card>
-        <v-card-title class="ma-2">
-          <span class="text-h5 font-weight-bold">メモの削除</span>
-        </v-card-title>
-        <v-card-text>
-          「{{ memoDetail.title }}」メモを削除してもよろしいですか？
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer />
-          <v-btn @click="handleCloseMemoDialog">
-            キャンセル
-          </v-btn>
-          <v-btn
-            class="mr-4"
             color="error"
-            @click="handleMemoDelete"
+            class="mt-4"
+            @click="handleOpenMemoDeleteDialog"
           >
-            削除
+            メモを削除する
           </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
-  </div>
+        </v-col>
+      </template>
+    </v-row>
+
+    <div class="justify-center">
+      <v-dialog
+        v-model="memoDeleteDialog"
+        width="500px"
+      >
+        <v-card>
+          <v-card-title class="ma-2">
+            <span class="text-h5 font-weight-bold">メモの削除</span>
+          </v-card-title>
+          <v-card-text>
+            「{{ memoDetail.title }}」メモを削除してもよろしいですか？
+          </v-card-text>
+          <v-card-actions>
+            <v-spacer />
+            <v-btn @click="handleCloseMemoDialog">
+              キャンセル
+            </v-btn>
+            <v-btn
+              class="mr-4"
+              color="error"
+              @click="handleMemoDelete"
+            >
+              削除
+            </v-btn>
+          </v-card-actions>
+        </v-card>
+      </v-dialog>
+    </div>
+  </template>
 </template>
 
 <script>
@@ -170,7 +172,10 @@ export default {
     };
   },
   computed: {
-    ...mapGetters("memos", ["memoDetail"]),
+    ...mapGetters("memos", [
+      "isDataReceived",
+      "memoDetail"
+    ]),
     isMatchup() {
       return this.$route.name == "MatchupMemosShow";
     },

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -182,14 +182,17 @@ export default {
     }
   },
   created() {
-    this.$store.dispatch("memos/fetchMemoDetail", this.$route.params.memoId)
+    this.fetchMemoDetail(this.$route.params.memoId)
       .catch(() => {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });
         this.$router.push({ name: "TopIndex" });
       });
   },
   methods: {
-    ...mapActions("memos", ["deleteMemo"]),
+    ...mapActions("memos", [
+      "fetchMemoDetail",
+      "deleteMemo"
+    ]),
     ...mapActions("alert", [
       "displayAlert",
       "closeAlertWithCross"

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -172,7 +172,7 @@ export default {
   computed: {
     ...mapGetters("memos", ["memoDetail"]),
     isMatchup() {
-      return this.$route.name == "MatchupMemosShow" ? true : false;
+      return this.$route.name == "MatchupMemosShow";
     },
     pageInformation() {
       return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -47,6 +47,11 @@
           </template>
         </template>
         <template v-else-if="memoBlock.blockableType == 'Image'">
+          <template v-if="isTemplate">
+            <div class="text-caption mt-n4 ml-4">
+              テンプレートの画像メモブロックは見出しと画像サイズのみ指定できます。
+            </div>
+          </template>
           <v-text-field
             v-model="v$.image.subtitle.$model"
             :error-messages="v$.image.subtitle.$errors.map(e => e.$message)"
@@ -65,6 +70,7 @@
             />
           </template>
           <v-file-input
+            :disabled="isTemplate"
             label="ファイルを選択してください"
             prepend-icon=""
             variant="underlined"
@@ -265,6 +271,9 @@ export default {
     };
   },
   computed: {
+    isTemplate() {
+      return this.$route.name == "MatchupTemplate";
+    },
     previewUrl() {
       return this.formPreviewUrl ? this.formPreviewUrl
         : this.image.pictureUrl ? this.image.pictureUrl

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -108,7 +108,7 @@ export default {
   },
   computed: {
     isMatchup() {
-      return this.$route.name == "MatchupMemosIndex" ? true : false;
+      return this.$route.name == "MatchupMemosIndex";
     }
   },
   validations () {

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -96,7 +96,7 @@ export default {
   },
   computed: {
     isMatchup() {
-      return this.$route.name == "MatchupMemosEdit" ? true : false;
+      return this.$route.name == "MatchupMemosEdit";
     },
     memoStateLabel() {
       return this.memoStates[this.memo.state];

--- a/app/frontend/pages/static_pages/TopIndex.vue
+++ b/app/frontend/pages/static_pages/TopIndex.vue
@@ -78,12 +78,12 @@
               v-for="folderItem in strategyFolders"
               :key="folderItem.id"
             >
-                <v-list-item
-                  :title="folderItem.name"
-                  :subtitle="dateFormat(folderItem.updatedAt)"
-                  :to="{ path: `/strategy/${folderItem.id}/memos` }"
-                  :prepend-icon="mdiFolder"
-                />
+              <v-list-item
+                :title="folderItem.name"
+                :subtitle="dateFormat(folderItem.updatedAt)"
+                :to="{ path: `/strategy/${folderItem.id}/memos` }"
+                :prepend-icon="mdiFolder"
+              />
             </template>
           </v-list>
         </v-card-text>
@@ -115,12 +115,12 @@
                 v-for="folderItem in matchupFolders"
                 :key="folderItem.id"
               >
-                  <v-list-item
-                    :title="folderItem.name"
-                    :subtitle="dateFormat(folderItem.updatedAt)"
-                    :to="{ path: `/matchup/${folderItem.id}/memos` }"
-                    :prepend-icon="mdiFolder"
-                  />
+                <v-list-item
+                  :title="folderItem.name"
+                  :subtitle="dateFormat(folderItem.updatedAt)"
+                  :to="{ path: `/matchup/${folderItem.id}/memos` }"
+                  :prepend-icon="mdiFolder"
+                />
               </template>
             </v-list>
           </v-card-text>
@@ -144,7 +144,7 @@ export default {
   data() {
     return {
       mdiFolder
-    }
+    };
   },
   computed: {
     ...mapGetters("users", ["authUser"]),
@@ -157,12 +157,12 @@ export default {
     matchupFolders() {
       return this.folders.filter(folder => {
         return folder.type == "MatchupFolder";
-      })
+      });
     },
     strategyFolders() {
       return this.folders.filter(folder => {
         return folder.type == "StrategyFolder";
-      })
+      });
     }
   },
   created() {
@@ -175,3 +175,9 @@ export default {
   }
 };
 </script>
+
+<style>
+.text-body-1 {
+  line-height: 1.7em;
+}
+</style>

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -43,6 +43,12 @@ const routes = [
     meta: { requiredAuth: true }
   },
   {
+    path: "/matchup/:folderId/template",
+    name: "MatchupTemplate",
+    component: MemosEdit,
+    meta: { requiredAuth: true }
+  },
+  {
     path: "/matchup/:folderId/memos",
     name: "MatchupMemosIndex",
     component: MemosIndex,

--- a/app/frontend/store/modules/folders.js
+++ b/app/frontend/store/modules/folders.js
@@ -1,14 +1,19 @@
 import axios from '../../plugins/axios';
 
 const state = {
+  isDataReceived: false,
   folders: []
 };
 
 const getters = {
+  isDataReceived: state => state.isDataReceived,
   folders: state => state.folders
 };
 
 const mutations = {
+  setDataComplete: (state) => {
+    state.isDataReceived = true;
+  },
   setFolders: (state, folders) => {
     state.folders = folders;
   },
@@ -33,6 +38,7 @@ const actions = {
     axios.get('folders', { params: { type: folderType } })
       .then(res => {
         commit("setFolders", res.data);
+        commit("setDataComplete");
       })
       .catch(err => console.log(err.response));
   },

--- a/app/frontend/store/modules/memos.js
+++ b/app/frontend/store/modules/memos.js
@@ -1,6 +1,7 @@
 import axios from '../../plugins/axios';
 
 const state = {
+  isDataReceived: false,
   folder: [],
   memos: [],
   memoRemovedKeys: [],
@@ -10,12 +11,16 @@ const state = {
 };
 
 const getters = {
+  isDataReceived: state => state.isDataReceived,
   folder: state => state.folder,
   memos: state => state.memos,
   memoDetail: state => state.memoDetail
 };
 
 const mutations = {
+  setDataComplete: (state) => {
+    state.isDataReceived = true;
+  },
   setFolder: (state, folder) => {
     state.folder = folder;
   },
@@ -69,19 +74,22 @@ const actions = {
     return axios.get(`folders/${folderId}/memos`)
       .then(res => {
         commit("setFolder", res.data);
-        commit("setMemos", res.data.memos);
+        commit("setMemos", res.data.memosExcludedTemplate);
+        commit("setDataComplete");
       });
   },
   fetchTemplate({ commit }, folderId) {
     return axios.get(`folders/${folderId}/template`)
       .then(res => {
         commit("setMemoDetail", res.data);
+        commit("setDataComplete");
       });
   },
   fetchMemoDetail({ commit }, memoId) {
     return axios.get(`memos/${memoId}`)
       .then(res => {
         commit("setMemoDetail", res.data);
+        commit("setDataComplete");
       });
   },
   createMemo({ commit }, { memo, memoType, folderId, applyTemplate }) {

--- a/app/frontend/store/modules/memos.js
+++ b/app/frontend/store/modules/memos.js
@@ -1,7 +1,7 @@
 import axios from '../../plugins/axios';
 
 const state = {
-  folderName: "",
+  folder: [],
   memos: [],
   memoRemovedKeys: [],
   memoDetail: {
@@ -10,14 +10,14 @@ const state = {
 };
 
 const getters = {
-  folderName: state => state.folderName,
+  folder: state => state.folder,
   memos: state => state.memos,
   memoDetail: state => state.memoDetail
 };
 
 const mutations = {
-  setFolder: (state, folderName) => {
-    state.folderName = folderName;
+  setFolder: (state, folder) => {
+    state.folder = folder;
   },
   setMemos: (state, memos) => {
     state.memos = memos;
@@ -68,8 +68,14 @@ const actions = {
   fetchMemos({ commit }, folderId) {
     return axios.get(`folders/${folderId}/memos`)
       .then(res => {
-        commit("setFolder", res.data.name);
+        commit("setFolder", res.data);
         commit("setMemos", res.data.memos);
+      });
+  },
+  fetchTemplate({ commit }, folderId) {
+    return axios.get(`folders/${folderId}/template`)
+      .then(res => {
+        commit("setMemoDetail", res.data);
       });
   },
   fetchMemoDetail({ commit }, memoId) {

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -5,4 +5,8 @@ class Folder < ApplicationRecord
   has_many :memos, dependent: :destroy
 
   validates :name, presence: true, length: { maximum: 30 }
+
+  def memos_excluded_template
+    memos.where.not(type: "TemplateMemo")
+  end
 end

--- a/app/models/matchup_folder.rb
+++ b/app/models/matchup_folder.rb
@@ -1,2 +1,3 @@
 class MatchupFolder < Folder
+  has_one :template_memo, foreign_key: "folder_id"
 end

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -12,4 +12,16 @@ class Memo < ApplicationRecord
   validates :title, presence: true, length: { maximum: 30 }
 
   enum state: { local: 0, shared: 1 }
+
+  def apply_template!
+    return nil if folder.type != "MatchupFolder"
+    template_memo_blocks = folder.template_memo.memo_blocks
+    template_memo_blocks.each do |template_memo_block|
+      blockable = template_memo_block.blockable.dup
+      blockable.save!
+      memo_block = template_memo_block.dup
+      memo_block.attributes = { blockable: blockable, memo: self }
+      memo_block.save!
+    end
+  end
 end

--- a/app/models/memo_block.rb
+++ b/app/models/memo_block.rb
@@ -22,14 +22,15 @@ class MemoBlock < ApplicationRecord
     end
   end
 
-  def create_blockable!(type)
+  def create_blockable!(type, blockable_params)
     case type
     when "Sentence"
-      self.blockable = Sentence.create!
+      self.blockable = Sentence.create!(blockable_params)
     when "Image"
-      self.blockable = Image.create!
+      self.blockable = Image.create!(blockable_params)
+      self.blockable.parse_base64(blockable_params[:file])
     when "Embed"
-      self.blockable = Embed.create!
+      self.blockable = Embed.create!(blockable_params)
     else
       raise "不正なブロックタイプです (#{type})"
     end

--- a/app/models/template_memo.rb
+++ b/app/models/template_memo.rb
@@ -1,0 +1,2 @@
+class TemplateMemo < Memo
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     resources :sessions, only: %i[create]
     resources :folders, only: %i[index create update destroy] do
       resources :memos, only: %i[index create]
+      get 'template', to: 'memos#template'
     end
     resources :memos, only: %i[show update destroy] do
       resources :memo_blocks, only: %i[create update destroy]


### PR DESCRIPTION
### 概要
- キャラ対メモのテンプレートの編集ができるように追加

### 確認項目
- キャラ対メモ一覧ページの「テンプレートを編集する」ボタンからテンプレートの編集が行えること
- キャラ対メモ作成時に、「テンプレートを適用する」にチェックを入れると、テンプレートに設定したメモブロックが追加されること
- 「テンプレートを適用する」にチェックを入れないようにすると、メモブロックがない状態のメモが作成されること