### PR TITLE
みんなのメモ詳細画面の追加

### DIFF
--- a/app/controllers/api/shared_controller.rb
+++ b/app/controllers/api/shared_controller.rb
@@ -11,6 +11,6 @@ class Api::SharedController < ApplicationController
 
   def show
     @memo = Memo.shared.find(params[:id])
-    render json: @memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}, user: {only: :name}]
+    render json: @memo, methods: [:type], include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}, user: {only: :name}]
   end
 end

--- a/app/controllers/api/shared_controller.rb
+++ b/app/controllers/api/shared_controller.rb
@@ -1,5 +1,5 @@
 class Api::SharedController < ApplicationController
-  skip_before_action :authenticate!, only: %i[index]
+  skip_before_action :authenticate!, only: %i[index show]
 
   def index
     @memos = Memo.where(type: params[:type]).shared.order(updated_at: :desc).page(params[:page]).per(12)
@@ -7,5 +7,10 @@ class Api::SharedController < ApplicationController
       memos: @memos.as_json(methods: [:type, :sentence_body], include: [user: {only: :name}]),
       total_pages: @memos.total_pages
     }
+  end
+
+  def show
+    @memo = Memo.shared.find(params[:id])
+    render json: @memo, include: [{memo_blocks: {include: [blockable: {methods: :picture_url}]}}, user: {only: :name}]
   end
 end

--- a/app/frontend/app.vue
+++ b/app/frontend/app.vue
@@ -35,4 +35,9 @@ a {
 .main-contents {
   margin-bottom: 60px;
 }
+
+.link-decoration {
+  text-decoration: underline;
+  color: #0099CC;
+}
 </style>

--- a/app/frontend/app.vue
+++ b/app/frontend/app.vue
@@ -32,6 +32,10 @@ a {
   color: inherit;
 }
 
+ol, ul {
+  margin-left: 20px;
+}
+
 .main-contents {
   margin-bottom: 60px;
 }

--- a/app/frontend/pages/memos/common/FoldersIndex.vue
+++ b/app/frontend/pages/memos/common/FoldersIndex.vue
@@ -180,6 +180,7 @@ export default {
   },
   beforeRouteUpdate(){
     this.isDataReceived = false;
+    next();
   },
   data() {
     return {

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -277,6 +277,7 @@ export default {
         })
         .catch(() => {
           this.displayAlert({ alertStatus: serverErrorAlertStatus });
+          this.applyTransition();
           this.$router.push({ name: "TopIndex" });
         });
     } else {
@@ -287,6 +288,7 @@ export default {
         })
         .catch(() => {
           this.displayAlert({ alertStatus: serverErrorAlertStatus });
+          this.applyTransition();
           this.$router.push({ name: "TopIndex" });
         });
     }
@@ -305,7 +307,8 @@ export default {
     ]),
     ...mapActions("alert", [
       "displayAlert",
-      "closeAlertWithCross"
+      "closeAlertWithCross",
+      "applyTransition"
     ]),
     handleOpenMemoBlockCreateDialog() {
       this.memoBlockInitialize();

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -275,6 +275,7 @@ export default {
       })
       .catch(() => {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });
+        this.applyTransition();
         this.$router.push({ name: "TopIndex" });
       });
   },
@@ -287,7 +288,8 @@ export default {
     ]),
     ...mapActions("alert", [
       "displayAlert",
-      "closeAlertWithCross"
+      "closeAlertWithCross",
+      "applyTransition"
     ]),
     handleOpenMemoCreateDialog() {
       this.memo = Object.assign({}, this.memoDefault);

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -87,6 +87,7 @@
           </v-layout>
         </template>
       </v-col>
+
       <template v-if="$vuetify.display.mdAndUp">
         <v-col
           md="4"
@@ -154,7 +155,7 @@ import EmbedYoutube from '../components/EmbedYoutube';
 import { sanitizeText } from '../../../plugins/sanitizeText';
 
 export default {
-  name: "MemosEdit",
+  name: "MemosShow",
   components: {
     EmbedYoutube
   },
@@ -185,12 +186,13 @@ export default {
     }
   },
   mounted() {
-    this.fetchMemoDetail(this.$route.params.memoId)
+    this.fetchMemoDetail(this.memoId)
       .then(() => {
           this.isDataReceived = true;
       })
       .catch(() => {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });
+        this.applyTransition();
         this.$router.push({ name: "TopIndex" });
       });
   },
@@ -201,7 +203,8 @@ export default {
     ]),
     ...mapActions("alert", [
       "displayAlert",
-      "closeAlertWithCross"
+      "closeAlertWithCross",
+      "applyTransition"
     ]),
     handleOpenMemoDeleteDialog() {
       this.memoDeleteDialog = true;

--- a/app/frontend/pages/memos/components/FolderFormDialog.vue
+++ b/app/frontend/pages/memos/components/FolderFormDialog.vue
@@ -5,7 +5,7 @@
     </v-card-title>
     <v-card-text>
       <TheAlert :is-dialog="true" />
-      <form>
+      <form @submit.prevent>
         <v-text-field
           v-model="v$.folder.name.$model"
           :error-messages="v$.folder.name.$errors.map(e => e.$message)"
@@ -97,7 +97,7 @@ export default {
   validations () {
     return {
       folder: {
-        name: { 
+        name: {
           maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
         },
         fighterId: {

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -5,7 +5,7 @@
     </v-card-title>
     <v-card-text>
       <TheAlert :is-dialog="true" />
-      <form>
+      <form @submit.prevent>
         <v-radio-group
           v-model="v$.memoBlock.blockableType.$model"
           inline

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -5,7 +5,7 @@
     </v-card-title>
     <v-card-text>
       <TheAlert :is-dialog="true" />
-      <form>
+      <form @submit.prevent>
         <v-text-field
           v-model="v$.memo.title.$model"
           :error-messages="v$.memo.title.$errors.map(e => e.$message)"

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <form>
+  <form @submit.prevent>
     <v-text-field
       v-model="v$.memo.title.$model"
       :error-messages="v$.memo.title.$errors.map(e => e.$message)"

--- a/app/frontend/pages/memos/components/SharedMemosList.vue
+++ b/app/frontend/pages/memos/components/SharedMemosList.vue
@@ -22,9 +22,11 @@
               :image="getImageUrl(memoItem.fighterId)"
               class="mr-2"
             />
-            <span class="memo-card-link">
-              {{ omittedText(memoItem.title, 12) }}
-            </span>
+            <router-link :to="{ name: pageInformation.showRouteName, params: { memoId: memoItem.id }, query: {} }">
+              <span class="link-decoration">
+                {{ omittedText(memoItem.title, 12) }}
+              </span>
+            </router-link>
             <template v-if="authUser && !isMine(memoItem.userId)">
               <v-btn
                 icon
@@ -50,7 +52,7 @@
           <v-card-actions class="mt-n4">
             <v-spacer />
             <div class="justify-end mr-4">
-              <p class="text-right memo-card-link">
+              <p class="text-right link-decoration">
                 {{ sliceUserName(memoItem.user.name) }}
               </p>
               <p class="text-right text-caption font-weight-thin">
@@ -87,10 +89,24 @@ export default {
   },
   data() {
     return {
+      pageInformationMatchup: {
+        showRouteName: "SharedMatchupMemosShow"
+      },
+      pageInformationStrategy: {
+        showRouteName: "SharedStrategyMemosShow"
+      },
       mdiStarOutline,
       mdiStar,
       FIGHTERS_ARRAY
     };
+  },
+  computed: {
+    isMatchup() {
+      return this.$route.name == "SharedMatchupMemosIndex";
+    },
+    pageInformation() {
+      return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
+    }
   },
   methods: {
     omittedText(text, length) {
@@ -119,11 +135,6 @@ export default {
 </script>
 
 <style scoped>
-.memo-card-link {
-  text-decoration: underline;
-  color: #0099CC;
-}
-
 .memo-card {
   position: relative;
 }

--- a/app/frontend/pages/memos/components/SharedMemosList.vue
+++ b/app/frontend/pages/memos/components/SharedMemosList.vue
@@ -22,7 +22,7 @@
               :image="getImageUrl(memoItem.fighterId)"
               class="mr-2"
             />
-            <router-link :to="{ name: pageInformation.showRouteName, params: { memoId: memoItem.id }, query: {} }">
+            <router-link :to="{ name: showRouteName(memoItem.type), params: { memoId: memoItem.id }, query: {} }">
               <span class="link-decoration">
                 {{ omittedText(memoItem.title, 12) }}
               </span>
@@ -89,24 +89,10 @@ export default {
   },
   data() {
     return {
-      pageInformationMatchup: {
-        showRouteName: "SharedMatchupMemosShow"
-      },
-      pageInformationStrategy: {
-        showRouteName: "SharedStrategyMemosShow"
-      },
       mdiStarOutline,
       mdiStar,
       FIGHTERS_ARRAY
     };
-  },
-  computed: {
-    isMatchup() {
-      return this.$route.name == "SharedMatchupMemosIndex";
-    },
-    pageInformation() {
-      return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
-    }
   },
   methods: {
     omittedText(text, length) {
@@ -122,6 +108,9 @@ export default {
     },
     isMine(userId) {
       return userId == this.authUser.id;
+    },
+    showRouteName(memoType) {
+      return memoType == "MatchupMemo" ? "SharedMatchupMemosShow" : "SharedStrategyMemosShow";
     },
     dateFormat(date) {
       return dayjs(date).format("YYYY-MM-DD");

--- a/app/frontend/pages/memos/shared/SharedMemosIndex.vue
+++ b/app/frontend/pages/memos/shared/SharedMemosIndex.vue
@@ -103,20 +103,27 @@ export default {
     },
     pageQuery() {
       return this.$route.query.page ? Number(this.$route.query.page) : 1;
+    },
+    isTransitionWithinSame() {
+      return ["SharedMatchupMemosIndex", "SharedStrategyMemosIndex"].includes(this.$route.name);
     }
   },
   watch: {
     memoType: function(newVal) {
-      if (this.page == 1) {
-        this.fetchSharedMemos({ memoType: newVal, page: this.page });
-        this.$router.push({ name: this.$route.name, query: { page: 1 }});
-      } else {
-        this.page = 1;
+      if (this.isTransitionWithinSame) {
+        if (this.page == 1) {
+          this.fetchSharedMemos({ memoType: newVal, page: this.page });
+          this.$router.push({ name: this.$route.name, query: { page: 1 }});
+        } else {
+          this.page = 1;
+        }
       }
     },
     page: function(newVal) {
-      this.fetchSharedMemos({ memoType: this.memoType, page: newVal });
-      this.$router.push({ name: this.$route.name, query: { page: newVal }});
+      if (this.isTransitionWithinSame) {
+        this.fetchSharedMemos({ memoType: this.memoType, page: newVal });
+        this.$router.push({ name: this.$route.name, query: { page: newVal }});
+      }
     },
     pageQuery: function(newVal) {
       this.page = newVal;

--- a/app/frontend/pages/memos/shared/SharedMemosShow.vue
+++ b/app/frontend/pages/memos/shared/SharedMemosShow.vue
@@ -46,9 +46,6 @@
               </template>
             </template>
           </div>
-          <div class="d-flex flex-row justify-end mt-8">
-            
-          </div>
         </template>
       </v-col>
 

--- a/app/frontend/pages/memos/shared/SharedMemosShow.vue
+++ b/app/frontend/pages/memos/shared/SharedMemosShow.vue
@@ -124,7 +124,7 @@ export default {
     ...mapGetters("users", ["authUser"]),
     ...mapGetters("shared", ["memoDetail"]),
     isMatchup() {
-      return this.$route.name == "SharedMatchupMemosShow";
+      return this.memoDetail.type == "MatchupMemo";
     },
     memoId() {
       return this.$route.params.memoId;

--- a/app/frontend/pages/memos/shared/SharedMemosShow.vue
+++ b/app/frontend/pages/memos/shared/SharedMemosShow.vue
@@ -1,0 +1,162 @@
+<template>
+  <template v-if="isDataReceived">
+    <div class="text-md-h3 text-h4 font-weight-bold">
+      {{ memoDetail.title }}
+    </div>
+
+    <div class="my-6" />
+
+    <v-row>
+      <v-col
+        cols="12"
+        md="8"
+        lg="8"
+        xl="8"
+      >
+        <template v-if="memoDetail.memoBlocks.length">
+          <div style="min-height: 55vh;">
+            <template
+              v-for="memoBlockItem in memoDetail.memoBlocks"
+              :key="memoBlockItem.id"
+            >
+              <template v-if="!(memoBlockItem.blockable.subtitle == '')">
+                <div class="text-md-h5 text-h6 mb-4">
+                  {{ memoBlockItem.blockable.subtitle }}
+                </div>
+              </template>
+              <template v-if="memoBlockItem.blockableType == 'Sentence'">
+                <div
+                  class="ml-2 mt-n2 mb-4"
+                  v-html="sanitizeHtml(memoBlockItem.blockable.body)"
+                />
+              </template>
+              <template v-else-if="memoBlockItem.blockableType == 'Image'">
+                <v-img
+                  :src="memoBlockItem.blockable.pictureUrl"
+                  :width="memoBlockItem.blockable.pictureWidth"
+                  class="ml-2 mt-n2 mb-4"
+                />
+              </template>
+              <template v-else-if="memoBlockItem.blockableType == 'Embed'">
+                <div class="ml-2 mt-n2 mb-4">
+                  <EmbedYoutube
+                    :youtube-url="memoBlockItem.blockable.identifier"
+                  />
+                </div>
+              </template>
+            </template>
+          </div>
+          <div class="d-flex flex-row justify-end mt-8">
+            
+          </div>
+        </template>
+      </v-col>
+
+      <template v-if="$vuetify.display.smAndDown">
+        <v-divider thickness="5" />
+      </template>
+
+      <v-col
+        cols="12"
+        md="3"
+        lg="3"
+        xl="2"
+      >
+        <div class="d-flex flex-row justify-end align-center mb-2">
+          <span class="mr-3">使用ファイター</span>
+          <v-avatar :image="getImageUrl(memoDetail.fighterId)" />
+        </div>
+        <template v-if="isMatchup">
+          <div class="d-flex flex-row justify-end align-center mb-2">
+            <span class="mr-3">相手ファイター</span>
+            <v-avatar :image="getImageUrl(memoDetail.opponentId)" />
+          </div>
+        </template>
+
+        <div class="my-6" />
+
+        <template v-if="authUser && !isMine(memoDetail.userId)">
+          <div class="d-flex flex-row justify-end mb-2">
+            <v-btn
+              variant="elevated"
+              elevation="2"
+              :prepend-icon="mdiStarOutline"
+              color="teal-accent-4"
+            >
+              ブックマーク
+            </v-btn>
+          </div>
+        </template>
+        <p class="text-right link-decoration">
+          {{ memoDetail.user.name }}
+        </p>
+        <p class="text-right text-caption font-weight-thin">
+          {{ dateFormat(memoDetail.updatedAt) }}
+        </p>
+      </v-col>
+    </v-row>
+  </template>
+</template>
+
+<script>
+import { mdiStarOutline, mdiStar } from '@mdi/js';
+import { mapGetters, mapActions } from 'vuex';
+import { serverErrorAlertStatus } from '../../../constants/alertStatus';
+import EmbedYoutube from '../components/EmbedYoutube';
+import { sanitizeText } from '../../../plugins/sanitizeText';
+import dayjs from 'dayjs';
+import { FIGHTERS_ARRAY } from '../../../constants/fightersArray';
+
+export default {
+  name: "SharedMemosShow",
+  components: {
+    EmbedYoutube
+  },
+  data() {
+    return {
+      isDataReceived: false,
+      mdiStarOutline,
+      mdiStar,
+      FIGHTERS_ARRAY
+    };
+  },
+  computed: {
+    ...mapGetters("users", ["authUser"]),
+    ...mapGetters("shared", ["memoDetail"]),
+    isMatchup() {
+      return this.$route.name == "SharedMatchupMemosShow";
+    },
+    memoId() {
+      return this.$route.params.memoId;
+    }
+  },
+  mounted() {
+    this.fetchMemoDetail(this.memoId)
+      .then(() => {
+          this.isDataReceived = true;
+      })
+      .catch(() => {
+        console.log("a");
+        this.displayAlert({ alertStatus: serverErrorAlertStatus });
+        this.$router.push({ name: "SharedStrategyMemosIndex" });
+      });
+  },
+  methods: {
+    ...mapActions("shared", ["fetchMemoDetail"]),
+    ...mapActions("alert", ["displayAlert"]),
+    isMine(userId) {
+      return userId == this.authUser.id;
+    },
+    getImageUrl(fighterId) {
+      const fighterData = this.FIGHTERS_ARRAY.find((fighter) => fighter.id == fighterId);
+      return new URL(`../../../../assets/images/character_icon/${fighterData.image}`, import.meta.url).href;
+    },
+    sanitizeHtml(html) {
+      return sanitizeText(html);
+    },
+    dateFormat(date) {
+      return dayjs(date).format("YYYY-MM-DD");
+    }
+  }
+};
+</script>

--- a/app/frontend/pages/memos/shared/SharedMemosShow.vue
+++ b/app/frontend/pages/memos/shared/SharedMemosShow.vue
@@ -136,14 +136,17 @@ export default {
           this.isDataReceived = true;
       })
       .catch(() => {
-        console.log("a");
         this.displayAlert({ alertStatus: serverErrorAlertStatus });
+        this.applyTransition();
         this.$router.push({ name: "SharedStrategyMemosIndex" });
       });
   },
   methods: {
     ...mapActions("shared", ["fetchMemoDetail"]),
-    ...mapActions("alert", ["displayAlert"]),
+    ...mapActions("alert", [
+      "displayAlert",
+      "applyTransition"
+    ]),
     isMine(userId) {
       return userId == this.authUser.id;
     },

--- a/app/frontend/pages/static_pages/TopIndex.vue
+++ b/app/frontend/pages/static_pages/TopIndex.vue
@@ -19,7 +19,7 @@
       まずは
       <router-link
         :to="{ name: 'Null' }"
-        class="top-page-link"
+        class="link-decoration"
       >
         お試しログイン
       </router-link>
@@ -31,7 +31,7 @@
     <div class="text-body-1 font-weight-bold">
       <router-link
         :to="{ name: 'SharedStrategyMemosIndex' }"
-        class="top-page-link"
+        class="link-decoration"
       >
         みんなのメモ
       </router-link>
@@ -57,7 +57,7 @@
     <div class="text-body-1 font-weight-bold">
       <router-link
         :to="{ name: 'StrategyFoldersIndex' }"
-        class="top-page-link"
+        class="link-decoration"
       >
         攻略メモ
       </router-link>
@@ -95,7 +95,7 @@
     <div class="text-body-1 font-weight-bold">
       <router-link
         :to="{ name: 'MatchupFoldersIndex' }"
-        class="top-page-link"
+        class="link-decoration"
       >
         キャラ対メモ
       </router-link>
@@ -147,7 +147,7 @@
   <div class="d-flex flex-row justify-end mt-4">
     <router-link
       :to="{ name: 'SharedStrategyMemosIndex' }"
-      class="top-page-link"
+      class="link-decoration"
     >
       もっと見る
     </router-link>
@@ -208,10 +208,5 @@ export default {
 <style>
 .text-body-1 {
   line-height: 1.7em;
-}
-
-.top-page-link {
-  text-decoration: underline;
-  color: #0099CC;
 }
 </style>

--- a/app/frontend/pages/static_pages/TopIndex.vue
+++ b/app/frontend/pages/static_pages/TopIndex.vue
@@ -165,6 +165,9 @@ export default {
   components: {
     SharedMemosList
   },
+  beforeRouteLeave(){
+    this.resetFolders();
+  },
   data() {
     return {
       mdiFolder
@@ -193,6 +196,7 @@ export default {
     this.fetchSharedMemos({ memoType: ["MatchupMemo", "StrategyMemo"], page: 1 });
   },
   methods: {
+    ...mapActions("folders", ["resetFolders"]),
     ...mapActions("shared", ["fetchSharedMemos"]),
     dateFormat(date) {
       return dayjs(date).format("YYYY-MM-DD");

--- a/app/frontend/pages/users/UsersLogin.vue
+++ b/app/frontend/pages/users/UsersLogin.vue
@@ -13,7 +13,7 @@
       lg="6"
       xl="6"
     >
-      <form id="login-form">
+      <form @submit.prevent id="login-form">
         <v-text-field
           v-model="v$.user.email.$model"
           :error-messages="v$.user.email.$errors.map(e => e.$message)"

--- a/app/frontend/pages/users/UsersLogin.vue
+++ b/app/frontend/pages/users/UsersLogin.vue
@@ -13,7 +13,10 @@
       lg="6"
       xl="6"
     >
-      <form @submit.prevent id="login-form">
+      <form
+        id="login-form"
+        @submit.prevent
+      >
         <v-text-field
           v-model="v$.user.email.$model"
           :error-messages="v$.user.email.$errors.map(e => e.$message)"

--- a/app/frontend/pages/users/UsersRegister.vue
+++ b/app/frontend/pages/users/UsersRegister.vue
@@ -13,7 +13,7 @@
       lg="6"
       xl="6"
     >
-      <form id="register-form">
+      <form @submit.prevent id="register-form">
         <v-text-field
           v-model="v$.user.name.$model"
           :error-messages="v$.user.name.$errors.map(e => e.$message)"

--- a/app/frontend/pages/users/UsersRegister.vue
+++ b/app/frontend/pages/users/UsersRegister.vue
@@ -13,7 +13,10 @@
       lg="6"
       xl="6"
     >
-      <form @submit.prevent id="register-form">
+      <form
+        id="register-form"
+        @submit.prevent
+      >
         <v-text-field
           v-model="v$.user.name.$model"
           :error-messages="v$.user.name.$errors.map(e => e.$message)"

--- a/app/frontend/router/index.js
+++ b/app/frontend/router/index.js
@@ -10,6 +10,7 @@ import MemosShow from '../pages/memos/common/MemosShow';
 import MemosEdit from '../pages/memos/common/MemosEdit';
 import SharedMemosIndex from '../pages/memos/shared/SharedMemosIndex';
 import SharedMemosList from '../pages/memos/components/SharedMemosList';
+import SharedMemosShow from '../pages/memos/shared/SharedMemosShow';
 
 import { requireLoginAlertStatus } from '../constants/alertStatus';
 
@@ -102,6 +103,18 @@ const routes = [
         component: SharedMemosList
       }
     ]
+  },
+  {
+    path: "/shared/matchup/:memoId",
+    name: "SharedMatchupMemosShow",
+    component: SharedMemosShow,
+    meta: { requiredAuth: false }
+  },
+  {
+    path: "/shared/strategy/:memoId",
+    name: "SharedStrategyMemosShow",
+    component: SharedMemosShow,
+    meta: { requiredAuth: false }
   },
   {
     path: "/null",

--- a/app/frontend/store/modules/alert.js
+++ b/app/frontend/store/modules/alert.js
@@ -35,6 +35,9 @@ const mutations = {
       state.isTransition = false;
     }
   },
+  isTransitionTrue: (state) => {
+    state.isTransition = true;
+  },
   isTransitionFalse: (state) => {
     state.isTransition = false;
   }
@@ -49,6 +52,9 @@ const actions = {
   },
   closeAlertWithCross({ commit }) {
     commit("resetAlert", true);
+  },
+  applyTransition({ commit }) {
+    commit("isTransitionTrue");
   },
   cancelTransition({ commit }) {
     commit("isTransitionFalse");

--- a/app/frontend/store/modules/folders.js
+++ b/app/frontend/store/modules/folders.js
@@ -25,6 +25,9 @@ const mutations = {
     state.folders = state.folders.filter(folder => {
       return folder.id != deleteFolder.id;
     });
+  },
+  resetFolders: (state) => {
+    state.folders = [];
   }
 };
 
@@ -53,6 +56,9 @@ const actions = {
       .then(res => {
         commit("deleteFolder", res.data);
       });
+  },
+  resetFolders({ commit }) {
+    commit("resetFolders");
   }
 };
 

--- a/app/frontend/store/modules/memos.js
+++ b/app/frontend/store/modules/memos.js
@@ -3,7 +3,6 @@ import axios from '../../plugins/axios';
 const state = {
   folder: [],
   memos: [],
-  memoRemovedKeys: [],
   memoDetail: {
     memoBlocks: []
   }
@@ -22,20 +21,20 @@ const mutations = {
   setMemos: (state, memos) => {
     state.memos = memos;
   },
-  setMemoDetail : (state, memo) => {
+  setMemoDetail: (state, memo) => {
     state.memoDetail = memo;
   },
-  addMemo: (state) => {
-    state.memos.push(state.memoRemovedKeys);
+  addMemo: (state, memo) => {
+    state.memos.push(memo);
   },
   addMemoBlock: (state, memoBlock) => {
     state.memoDetail.memoBlocks.push(memoBlock);
   },
-  updateMemo: (state) => {
+  updateMemo: (state, updateMemo) => {
     const index = state.memos.findIndex(memo => {
-      return memo.id == state.memoRemovedKeys.id;
+      return memo.id == updateMemo.id;
     });
-    state.memos.splice(index, 1, state.memoRemovedKeys);
+    state.memos.splice(index, 1, updateMemo);
   },
   updateMemoBlock: (state, updateMemoBlock) => {
     const index = state.memoDetail.memoBlocks.findIndex(memoBlock => {
@@ -52,15 +51,6 @@ const mutations = {
     state.memoDetail.memoBlocks = state.memoDetail.memoBlocks.filter(memoBlock => {
       return memoBlock.id != deleteMemoBlock.id;
     });
-  },
-  removeKeysOfMemoDetail: (state, memoDetail) => {
-    const keysToRemove = ["userId", "createdAt", "memoBlocks"];
-    state.memoRemovedKeys = Object.keys(memoDetail).reduce((result, key) => {
-      if (!keysToRemove.includes(key)) {
-        result[key] = memoDetail[key];
-      }
-      return result;
-    }, {});
   }
 };
 
@@ -88,8 +78,7 @@ const actions = {
     return axios.post(`folders/${folderId}/memos?apply_template=${applyTemplate}`,
                {...memo, type: memoType})
       .then(res => {
-        commit("removeKeysOfMemoDetail", res.data);
-        commit("addMemo");
+        commit("addMemo", res.data);
       });
   },
   createMemoBlock({ commit }, { memoId, memoBlockParams }) {
@@ -105,8 +94,7 @@ const actions = {
   updateMemo({ commit }, memo) {
     return axios.patch(`memos/${memo.id}`, memo)
       .then(res => {
-        commit("removeKeysOfMemoDetail", res.data);
-        commit("updateMemo");
+        commit("updateMemo", res.data);
       });
   },
   updateMemoBlock({ commit }, { memoId, memoBlockId, memoBlockParams }) {
@@ -122,8 +110,7 @@ const actions = {
   updateMemoState({ commit }, { memoId, memoState }) {
     return axios.patch(`memos/${memoId}`, { memo: { state: memoState}})
       .then(res => {
-        commit("removeKeysOfMemoDetail", res.data);
-        commit("updateMemo");
+        commit("updateMemo", res.data);
       });
   },
   deleteMemo({ commit }, memo) {

--- a/app/frontend/store/modules/shared.js
+++ b/app/frontend/store/modules/shared.js
@@ -2,12 +2,16 @@ import axios from '../../plugins/axios';
 
 const state = {
   sharedMemos: [],
-  totalPages: 1
+  totalPages: 1,
+  memoDetail: {
+    memoBlocks: []
+  }
 };
 
 const getters = {
   sharedMemos: state => state.sharedMemos,
-  totalPages: state => state.totalPages
+  totalPages: state => state.totalPages,
+  memoDetail: state => state.memoDetail
 };
 
 const mutations = {
@@ -16,6 +20,9 @@ const mutations = {
   },
   setTotalPages: (state, totalPages) => {
     state.totalPages = totalPages;
+  },
+  setMemoDetail: (state, memo) => {
+    state.memoDetail = memo;
   }
 };
 
@@ -25,6 +32,12 @@ const actions = {
       .then(res => {
         commit("setSharedMemos", res.data.memos);
         commit("setTotalPages", res.data.totalPages);
+      });
+  },
+  fetchMemoDetail({ commit }, memoId) {
+    return axios.get(`shared/${memoId}`)
+      .then(res => {
+        commit("setMemoDetail", res.data);
       });
   }
 };

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
     resources :memos, only: %i[show update destroy] do
       resources :memo_blocks, only: %i[create update destroy]
     end
-    resources :shared, only: %i[index]
+    resources :shared, only: %i[index show]
   end
 
   get '*path', to: 'top#index', constraints: lambda { |req|


### PR DESCRIPTION
### 概要
- みんなのメモ一覧に表示されているメモのタイトルをクリックすると、メモの詳細画面を閲覧できるように

### 確認項目
- メモのタイトルをクリックすると、メモ詳細画面に遷移すること
- 公開されていないメモなどのIDをURLに直に打ち込んでも、詳細画面を見れないこと