### PR TITLE
ローカルのメモの検索機能の追加

### DIFF
--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -9,9 +9,9 @@ class Api::MemosController < ApplicationController
   def create
     Memo.transaction do
       @memo = current_user.memos.build(memo_params.merge(
-                                         folder: @folder,
-                                         fighter: @folder.fighter
-                                       ))
+        folder: @folder,
+        fighter: @folder.fighter
+      ))
       @memo.title = @memo.opponent.name if @memo.title.blank? && @memo.type == "MatchupMemo"
 
       @memo.save!
@@ -19,11 +19,21 @@ class Api::MemosController < ApplicationController
       @memo.apply_template! if apply_template?
     end
 
-    render json: @memo, include: [{ memo_blocks: { include: [blockable: { methods: :picture_url }] } }]
+    @memo_blocks = @memo.memo_blocks.includes(:blockable)
+
+    render json: {
+      memo: @memo,
+      memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }])
+    }
   end
 
   def show
-    render json: @memo, include: [{ memo_blocks: { include: [blockable: { methods: :picture_url }] } }]
+    @memo_blocks = @memo.memo_blocks.includes(:blockable)
+
+    render json: {
+      memo: @memo,
+      memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }])
+    }
   end
 
   def update
@@ -31,7 +41,12 @@ class Api::MemosController < ApplicationController
     @memo.title = @memo.opponent.name if @memo.title.blank? && @memo.type == "MatchupMemo"
 
     if @memo.save
-      render json: @memo, include: [{ memo_blocks: { include: [blockable: { methods: :picture_url }] } }]
+      @memo_blocks = @memo.memo_blocks.includes(:blockable)
+
+      render json: {
+        memo: @memo,
+        memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }])
+      }
     else
       render json: @memo.errors.full_messages, status: :bad_request
     end
@@ -44,7 +59,12 @@ class Api::MemosController < ApplicationController
 
   def template
     @template_memo = @folder.template_memo
-    render json: @template_memo, include: [{ memo_blocks: { include: [blockable: { methods: :picture_url }] } }]
+    @memo_blocks = @template_memo.memo_blocks.includes(:blockable)
+
+    render json: {
+      memo: @template_memo,
+      memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }])
+    }
   end
 
   private

--- a/app/controllers/api/shared_controller.rb
+++ b/app/controllers/api/shared_controller.rb
@@ -2,7 +2,7 @@ class Api::SharedController < ApplicationController
   skip_before_action :authenticate!, only: %i[index show bookmarks]
 
   def index
-    @memos = Memo.where(type: params[:type]).shared.order(updated_at: :desc).page(params[:page]).per(12)
+    @memos = Memo.where(type: params[:type]).shared.order(updated_at: :desc).page(params[:page]).per(12).includes([:user, :sentences])
     @bookmark_memo_ids = current_user ? current_user.bookmark_memo_ids : []
     render json: {
       memos: @memos.as_json(methods: [:type, :sentence_body], include: [user: { only: :name }]),
@@ -13,15 +13,17 @@ class Api::SharedController < ApplicationController
 
   def show
     @memo = Memo.shared.find(params[:id])
+    @memo_blocks = @memo.memo_blocks.includes(:blockable)
     @bookmark_memo_ids = current_user ? current_user.bookmark_memo_ids : []
     render json: {
-      memo: @memo.as_json(methods: [:type], include: [{ memo_blocks: { include: [blockable: { methods: :picture_url }] } }, user: { only: :name }]),
+      memo: @memo.as_json(methods: [:type], include: [user: { only: :name }]),
+      memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }]),
       bookmark_memo_ids: @bookmark_memo_ids
     }
   end
 
   def bookmarks
-    @memos = current_user ? current_user.bookmark_memos.page(params[:page]).per(12) : Memo.none.page
+    @memos = current_user ? current_user.bookmark_memos.page(params[:page]).per(12).includes([:user, :sentences]) : Memo.none.page
     @bookmark_memo_ids = current_user ? current_user.bookmark_memo_ids : []
     render json: {
       memos: @memos.as_json(methods: [:type, :sentence_body], include: [user: { only: :name }]),

--- a/app/frontend/app.vue
+++ b/app/frontend/app.vue
@@ -38,6 +38,6 @@ a {
 
 .link-decoration {
   text-decoration: underline;
-  color: #FF9900;
+  color: #00B8D4;
 }
 </style>

--- a/app/frontend/components/TextEditor.vue
+++ b/app/frontend/components/TextEditor.vue
@@ -71,3 +71,9 @@ export default {
   }
 };
 </script>
+
+<style>
+.ql-editor {
+  font-size: 16px;
+}
+</style>

--- a/app/frontend/components/TopPageButton.vue
+++ b/app/frontend/components/TopPageButton.vue
@@ -1,0 +1,23 @@
+<template>
+  <v-btn
+    :to="{ name: path }"
+    color="cyan-accent-4"
+    outlined
+    rounded
+    class="font-weight-bold"
+  >
+    <slot />
+  </v-btn>
+</template>
+
+<script>
+export default {
+  name: "TopPageButton",
+  props: {
+    path: {
+      type: String,
+      required: true
+    }
+  }
+};
+</script>

--- a/app/frontend/constants/textConversion.js
+++ b/app/frontend/constants/textConversion.js
@@ -1,0 +1,7 @@
+export function textConversion(str) {
+  let result = str.toLowerCase();
+  return result.replace(/[\u30a1-\u30f6]/g, function(match) {
+		var chr = match.charCodeAt(0) - 0x60;
+		return String.fromCharCode(chr);
+	});
+};

--- a/app/frontend/pages/memos/common/MemosIndex.vue
+++ b/app/frontend/pages/memos/common/MemosIndex.vue
@@ -56,9 +56,24 @@
               </template>
             </div>
           </div>
+
+          <div class="d-flex flex-row ml-5 mb-n4">
+            <v-icon :icon="mdiMagnify" class="mt-4 mr-4" />
+            <v-text-field
+              v-model="titleSearchText"
+              label="タイトル"
+              variant="underlined"
+              clearable
+              density="compact"
+              single-line
+              class="mr-8"
+            />
+            <v-spacer v-if="!$vuetify.display.xs" />
+          </div>
+
           <v-list lines="two">
             <template
-              v-for="memoItem in sortedMemos"
+              v-for="memoItem in filteredMemos"
               :key="memoItem.id"
             >
               <div class="list-item-memo">
@@ -207,8 +222,9 @@
 
 <script>
 import { mapGetters, mapActions } from 'vuex';
-import { mdiFile, mdiInformationOutline } from '@mdi/js';
+import { mdiFile, mdiInformationOutline, mdiMagnify } from '@mdi/js';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
+import { textConversion } from '../../../constants/textConversion';
 import MemoCreateFormDialog from '../components/MemoCreateFormDialog';
 import dayjs from 'dayjs';
 
@@ -239,11 +255,13 @@ export default {
         opponentId: null
       },
       memo: {},
+      titleSearchText: "",
       memoCreateDialog: false,
       memoDeleteDialog: false,
       isDataReceived: false,
       mdiFile,
-      mdiInformationOutline
+      mdiInformationOutline,
+      mdiMagnify
     };
   },
   computed: {
@@ -260,12 +278,19 @@ export default {
     folderId() {
       return this.$route.params.folderId;
     },
-    sortedMemos() {
-      return this.memos.slice().sort((a, b) => {
+    filteredMemos() {
+      let result = this.memos.filter((memo) =>
+        textConversion(memo.title).includes(textConversion(this.titleSearchText)) ||
+        !this.titleSearchText
+        );
+
+      result = result.slice().sort((a, b) => {
         if (a.updatedAt > b.updatedAt) return -1;
         if (a.updatedAt < b.updatedAt) return 1;
         return 0;
       });
+
+      return result;
     }
   },
   mounted() {

--- a/app/frontend/pages/memos/components/FolderFormDialog.vue
+++ b/app/frontend/pages/memos/components/FolderFormDialog.vue
@@ -22,7 +22,6 @@
           item-value="id"
           item-title="name"
           clearable
-          :menu-props="{ location: 'top', scrollStrategy: 'none' }"
           name="使用ファイター"
           label="使用ファイター"
           hint="自分の使用ファイターを選択してください"

--- a/app/frontend/pages/memos/components/FolderFormDialog.vue
+++ b/app/frontend/pages/memos/components/FolderFormDialog.vue
@@ -9,7 +9,7 @@
         <v-text-field
           v-model="v$.folder.name.$model"
           :error-messages="v$.folder.name.$errors.map(e => e.$message)"
-          :counter="30"
+          :counter="nameMaxLength"
           name="フォルダ名"
           label="フォルダ名"
           hint="未入力の場合、下記の使用ファイター名が設定されます"
@@ -91,6 +91,7 @@ export default {
   },
   data() {
     return {
+      nameMaxLength: 25,
       fightersArray: FIGHTERS_ARRAY
     };
   },
@@ -98,7 +99,7 @@ export default {
     return {
       folder: {
         name: {
-          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
+          maxLength: helpers.withMessage(maxLengthMessage(this.nameMaxLength), maxLength(this.nameMaxLength))
         },
         fighterId: {
           required: helpers.withMessage(requiredMessage("使用ファイター"), required)

--- a/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoBlockFormDialog.vue
@@ -29,7 +29,7 @@
           <v-text-field
             v-model="v$.sentence.subtitle.$model"
             :error-messages="v$.sentence.subtitle.$errors.map(e => e.$message)"
-            :counter="30"
+            :counter="subtitleMaxLength"
             name="見出し"
             label="見出し"
             hint="未入力にすることも可能です"
@@ -55,7 +55,7 @@
           <v-text-field
             v-model="v$.image.subtitle.$model"
             :error-messages="v$.image.subtitle.$errors.map(e => e.$message)"
-            :counter="30"
+            :counter="subtitleMaxLength"
             name="見出し"
             label="見出し"
             hint="未入力にすることも可能です"
@@ -99,7 +99,7 @@
           <v-text-field
             v-model="v$.embed.subtitle.$model"
             :error-messages="v$.embed.subtitle.$errors.map(e => e.$message)"
-            :counter="30"
+            :counter="subtitleMaxLength"
             name="見出し"
             label="見出し"
             hint="未入力にすることも可能です"
@@ -265,6 +265,7 @@ export default {
   },
   data() {
     return {
+      subtitleMaxLength: 25,
       formPreviewUrl: "",
       embedYoutubeHelp: false,
       mdiHelpCircleOutline
@@ -287,7 +288,7 @@ export default {
       },
       sentence: {
         subtitle: { 
-          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
+          maxLength: helpers.withMessage(maxLengthMessage(this.subtitleMaxLength), maxLength(this.subtitleMaxLength))
         },
         body: {
           maxLength: helpers.withMessage("保存できる文字数を超えています", maxLength(65535))
@@ -295,7 +296,7 @@ export default {
       },
       image: {
         subtitle: { 
-          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
+          maxLength: helpers.withMessage(maxLengthMessage(this.subtitleMaxLength), maxLength(this.subtitleMaxLength))
         },
         file: {
           image: helpers.withMessage("無効なファイル形式です", image)
@@ -304,7 +305,7 @@ export default {
       },
       embed: {
         subtitle: { 
-          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
+          maxLength: helpers.withMessage(maxLengthMessage(this.subtitleMaxLength), maxLength(this.subtitleMaxLength))
         },
         embedType: {},
         identifier: {

--- a/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
+++ b/app/frontend/pages/memos/components/MemoCreateFormDialog.vue
@@ -9,7 +9,7 @@
         <v-text-field
           v-model="v$.memo.title.$model"
           :error-messages="v$.memo.title.$errors.map(e => e.$message)"
-          :counter="30"
+          :counter="titleMaxLength"
           name="タイトル"
           label="タイトル"
           :hint="formTitleHint"
@@ -102,6 +102,7 @@ export default {
   },
   data() {
     return {
+      titleMaxLength: 25,
       applyTemplate: false,
       fightersArray: FIGHTERS_ARRAY
     };
@@ -116,7 +117,7 @@ export default {
       memo: {
         title: {
           required: helpers.withMessage(requiredMessage("タイトル"), requiredIf(!this.isMatchup)),
-          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
+          maxLength: helpers.withMessage(maxLengthMessage(this.titleMaxLength), maxLength(this.titleMaxLength))
         },
         opponentId: {
           required: helpers.withMessage(requiredMessage("相手ファイター"), requiredIf(this.isMatchup))

--- a/app/frontend/pages/memos/components/MemoEditForm.vue
+++ b/app/frontend/pages/memos/components/MemoEditForm.vue
@@ -3,7 +3,7 @@
     <v-text-field
       v-model="v$.memo.title.$model"
       :error-messages="v$.memo.title.$errors.map(e => e.$message)"
-      :counter="30"
+      :counter="titleMaxLength"
       name="タイトル"
       label="タイトル"
       :hint="formTitleHint"
@@ -87,6 +87,7 @@ export default {
   },
   data() {
     return {
+      titleMaxLength: 25,
       memoStates: {
         local: "非公開",
         shared: "公開"
@@ -107,7 +108,7 @@ export default {
       memo: {
         title: { 
           required: helpers.withMessage(requiredMessage("タイトル"), requiredIf(!this.isMatchup)),
-          maxLength: helpers.withMessage(maxLengthMessage(30), maxLength(30))
+          maxLength: helpers.withMessage(maxLengthMessage(this.titleMaxLength), maxLength(this.titleMaxLength))
         },
         opponentId: {
           required: helpers.withMessage(requiredMessage("相手ファイター"), requiredIf(this.isMatchup))

--- a/app/frontend/pages/static_pages/TopIndex.vue
+++ b/app/frontend/pages/static_pages/TopIndex.vue
@@ -17,24 +17,18 @@
   <template v-if="!authUser">
     <div class="text-body-1 font-weight-bold">
       まずは
-      <router-link
-        :to="{ name: 'Null' }"
-        class="link-decoration"
-      >
+      <TopPageButton :path="'Null'">
         お試しログイン
-      </router-link>
+      </TopPageButton>
       でメモの作成を試してみましょう。
     </div>
 
     <div class="my-8" />
 
     <div class="text-body-1 font-weight-bold">
-      <router-link
-        :to="{ name: 'SharedStrategyMemosIndex' }"
-        class="link-decoration"
-      >
+      <TopPageButton :path="'SharedStrategyMemosIndex'">
         みんなのメモ
-      </router-link>
+      </TopPageButton>
       から他のユーザーが公開しているメモを見ることもできます。
     </div>
 
@@ -43,11 +37,15 @@
     <div>
       <v-btn
         :to="{ name: 'UsersLogin' }"
+        color="teal-accent-4"
         class="mx-8"
       >
         ログイン
       </v-btn>
-      <v-btn :to="{ name: 'UsersRegister' }">
+      <v-btn
+        :to="{ name: 'UsersRegister' }"
+        color="teal-accent-4"
+      >
         新規登録
       </v-btn>
     </div>
@@ -55,12 +53,9 @@
 
   <template v-else>
     <div class="text-body-1 font-weight-bold">
-      <router-link
-        :to="{ name: 'StrategyFoldersIndex' }"
-        class="link-decoration"
-      >
+      <TopPageButton :path="'StrategyFoldersIndex'">
         攻略メモ
-      </router-link>
+      </TopPageButton>
       では自分の使用しているファイターに関する立ち回りやコンボなどをまとめることができます。
     </div>
 
@@ -93,12 +88,9 @@
     <div class="my-6" />
 
     <div class="text-body-1 font-weight-bold">
-      <router-link
-        :to="{ name: 'MatchupFoldersIndex' }"
-        class="link-decoration"
-      >
+      <TopPageButton :path="'MatchupFoldersIndex'">
         キャラ対メモ
-      </router-link>
+      </TopPageButton>
       では相手ファイターの対策をファイターごとにまとめることができます。
 
       <template v-if="matchupFolders.length">
@@ -159,11 +151,13 @@ import { mapGetters, mapActions } from 'vuex';
 import { mdiFolder } from '@mdi/js';
 import dayjs from 'dayjs';
 import SharedMemosList from '../memos/components/SharedMemosList';
+import TopPageButton from '../../components/TopPageButton';
 
 export default {
   name: "TopIndex",
   components: {
-    SharedMemosList
+    SharedMemosList,
+    TopPageButton
   },
   beforeRouteLeave(){
     this.resetFolders();

--- a/app/frontend/store/modules/memos.js
+++ b/app/frontend/store/modules/memos.js
@@ -21,8 +21,9 @@ const mutations = {
   setMemos: (state, memos) => {
     state.memos = memos;
   },
-  setMemoDetail: (state, memo) => {
+  setMemoDetail: (state, { memo: memo, memoBlocks: memoBlocks }) => {
     state.memoDetail = memo;
+    state.memoDetail.memoBlocks = memoBlocks;
   },
   addMemo: (state, memo) => {
     state.memos.push(memo);
@@ -65,20 +66,20 @@ const actions = {
   fetchTemplate({ commit }, folderId) {
     return axios.get(`folders/${folderId}/template`)
       .then(res => {
-        commit("setMemoDetail", res.data);
+        commit("setMemoDetail", { memo: res.data.memo, memoBlocks: res.data.memoBlocks });
       });
   },
   fetchMemoDetail({ commit }, memoId) {
     return axios.get(`memos/${memoId}`)
       .then(res => {
-        commit("setMemoDetail", res.data);
+        commit("setMemoDetail", { memo: res.data.memo, memoBlocks: res.data.memoBlocks });
       });
   },
   createMemo({ commit }, { memo, memoType, folderId, applyTemplate }) {
     return axios.post(`folders/${folderId}/memos?apply_template=${applyTemplate}`,
                {...memo, type: memoType})
       .then(res => {
-        commit("addMemo", res.data);
+        commit("addMemo", res.data.memo);
       });
   },
   createMemoBlock({ commit }, { memoId, memoBlockParams }) {
@@ -94,7 +95,7 @@ const actions = {
   updateMemo({ commit }, memo) {
     return axios.patch(`memos/${memo.id}`, memo)
       .then(res => {
-        commit("updateMemo", res.data);
+        commit("updateMemo", res.data.memo);
       });
   },
   updateMemoBlock({ commit }, { memoId, memoBlockId, memoBlockParams }) {
@@ -110,7 +111,7 @@ const actions = {
   updateMemoState({ commit }, { memoId, memoState }) {
     return axios.patch(`memos/${memoId}`, { memo: { state: memoState}})
       .then(res => {
-        commit("updateMemo", res.data);
+        commit("updateMemo", res.data.memo);
       });
   },
   deleteMemo({ commit }, memo) {

--- a/app/frontend/store/modules/shared.js
+++ b/app/frontend/store/modules/shared.js
@@ -23,8 +23,9 @@ const mutations = {
   setTotalPages: (state, totalPages) => {
     state.totalPages = totalPages;
   },
-  setMemoDetail: (state, memo) => {
+  setMemoDetail: (state, { memo, memoBlocks }) => {
     state.memoDetail = memo;
+    state.memoDetail.memoBlocks = memoBlocks;
   },
   setBookmarkMemoIds: (state, bookmarkMemoIds) => {
     state.bookmarkMemoIds = bookmarkMemoIds;
@@ -59,7 +60,7 @@ const actions = {
   fetchMemoDetail({ commit }, memoId) {
     return axios.get(`shared/${memoId}`)
       .then(res => {
-        commit("setMemoDetail", res.data.memo);
+        commit("setMemoDetail", { memo: res.data.memo, memoBlocks: res.data.memoBlocks });
         commit("setBookmarkMemoIds", res.data.bookmarkMemoIds);
       });
   },

--- a/app/models/embed.rb
+++ b/app/models/embed.rb
@@ -2,7 +2,7 @@ class Embed < ApplicationRecord
   has_one :memo_block, as: :blockable, dependent: :destroy
   has_one :memo, through: :memo_block
 
-  validates :subtitle, length: { maximum: 30 }
+  validates :subtitle, length: { maximum: 25 }
   validates :identifier, length: { maximum: 200 }
 
   enum embed_type: { youtube: 0 }

--- a/app/models/folder.rb
+++ b/app/models/folder.rb
@@ -4,7 +4,7 @@ class Folder < ApplicationRecord
 
   has_many :memos, dependent: :destroy
 
-  validates :name, presence: true, length: { maximum: 30 }
+  validates :name, presence: true, length: { maximum: 25 }
 
   def memos_excluded_template
     memos.where.not(type: "TemplateMemo")

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -2,7 +2,7 @@ class Image < ApplicationRecord
   has_one :memo_block, as: :blockable, dependent: :destroy
   has_one :memo, through: :memo_block
 
-  validates :subtitle, length: { maximum: 30 }
+  validates :subtitle, length: { maximum: 25 }
   validates :picture_width, numericality: { only_integer: true, greater_than_or_equal_to: 200, less_than_or_equal_to: 800 }
 
   has_one_attached :picture

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -10,7 +10,7 @@ class Memo < ApplicationRecord
   has_many :embeds, through: :memo_blocks, source: :blockable, source_type: 'Embed'
   has_many :bookmarks, dependent: :destroy
 
-  validates :title, presence: true, length: { maximum: 30 }
+  validates :title, presence: true, length: { maximum: 25 }
 
   enum state: { local: 0, shared: 1 }
 

--- a/app/models/sentence.rb
+++ b/app/models/sentence.rb
@@ -2,7 +2,7 @@ class Sentence < ApplicationRecord
   has_one :memo_block, as: :blockable, dependent: :destroy
   has_one :memo, through: :memo_block
 
-  validates :subtitle, length: { maximum: 30 }
+  validates :subtitle, length: { maximum: 25 }
   validates :body, length: { maximum: 65_535 }
 
   def picture_url


### PR DESCRIPTION
### 概要
- 攻略メモ一覧・キャラ対メモ一覧ページにタイトルでの検索機能を追加

### 確認項目
- 検索したワードを含むメモのみが表示されること
- 大文字・小文字、ひらがな・カタカナの区別なく検索されること