### PR TITLE
パンくずリストの追加

### DIFF
--- a/app/controllers/api/memos_controller.rb
+++ b/app/controllers/api/memos_controller.rb
@@ -31,7 +31,7 @@ class Api::MemosController < ApplicationController
     @memo_blocks = @memo.memo_blocks.includes(:blockable)
 
     render json: {
-      memo: @memo,
+      memo: @memo.as_json(methods: :folder_information),
       memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }])
     }
   end
@@ -44,7 +44,7 @@ class Api::MemosController < ApplicationController
       @memo_blocks = @memo.memo_blocks.includes(:blockable)
 
       render json: {
-        memo: @memo,
+        memo: @memo.as_json(methods: :folder_information),
         memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }])
       }
     else
@@ -62,7 +62,7 @@ class Api::MemosController < ApplicationController
     @memo_blocks = @template_memo.memo_blocks.includes(:blockable)
 
     render json: {
-      memo: @template_memo,
+      memo: @template_memo.as_json(methods: :folder_information),
       memo_blocks: @memo_blocks.as_json(include: [blockable: { methods: :picture_url }])
     }
   end

--- a/app/frontend/components/BreadCrumbs.vue
+++ b/app/frontend/components/BreadCrumbs.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-breadcrumbs
+    :items="breadCrumbs"
+    density="compact"
+    class="mt-n4 ml-n4 mb-1"
+  >
+    <template #title="{ item }">
+      {{ omittedText(item.title, item.notOmit) }}
+    </template>
+    <template #divider>
+      <v-icon
+        :icon="mdiChevronRight"
+        class="mx-n2"
+      />
+    </template>
+  </v-breadcrumbs>
+</template>
+
+<script>
+import { mdiChevronRight } from '@mdi/js';
+
+export default {
+  name: "BreadCrumbs",
+  props: {
+    breadCrumbs: {
+      type: Object,
+      required: true
+    }
+  },
+  data() {
+    return {
+      mdiChevronRight
+    };
+  },
+  computed: {
+    breadCrumbLength() {
+      switch (this.$vuetify.display.name) {
+        case "xs":
+          return this.breadCrumbs.length <= 2 ? 6 : 4;
+        case "sm":
+          return this.breadCrumbs.length <= 2 ? 12 : 10;
+        case "md":
+          return 20;
+        default:
+          return this.breadCrumbs[0].length;
+      }
+    }
+  },
+  methods: {
+    omittedText(text, notOmit) {
+      return text.length > this.breadCrumbLength && !notOmit ? text.slice(0, this.breadCrumbLength) + "…" : text;
+    }
+  }
+};
+</script>

--- a/app/frontend/pages/memos/common/MemosEdit.vue
+++ b/app/frontend/pages/memos/common/MemosEdit.vue
@@ -1,5 +1,9 @@
 <template>
   <template v-if="isDataReceived">
+    <BreadCrumbs
+      :bread-crumbs="breadCrumbs"
+    />
+
     <div class="text-md-h3 text-h4 font-weight-bold">
       {{ memoDetail.title }}
     </div>
@@ -222,6 +226,7 @@ import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import MemoBlockFormDialog from '../components/MemoBlockFormDialog';
 import MemoEditForm from '../components/MemoEditForm';
 import EmbedYoutube from '../components/EmbedYoutube';
+import BreadCrumbs from '../../../components/BreadCrumbs';
 import { sanitizeText } from '../../../plugins/sanitizeText';
 import { mdiChevronUp, mdiChevronDown } from '@mdi/js';
 
@@ -230,7 +235,8 @@ export default {
   components: {
     MemoBlockFormDialog,
     MemoEditForm,
-    EmbedYoutube
+    EmbedYoutube,
+    BreadCrumbs
   },
   data() {
     return {
@@ -278,6 +284,7 @@ export default {
       sentence: {},
       image: {},
       embed: {},
+      breadCrumbs: [],
       isDataReceived: false,
       mdiChevronUp,
       mdiChevronDown
@@ -291,6 +298,15 @@ export default {
     },
     isMatchup() {
       return this.$route.name == "MatchupMemosEdit";
+    },
+    urlMemoType() {
+      return this.isMatchup ? "matchup" : "strategy";
+    },
+    memosIndexPath() {
+      return `/${this.urlMemoType}/${this.memoDetail.folderInformation.id}/memos`;
+    },
+    memosShowPath() {
+      return `/${this.urlMemoType}/memos/${this.memoDetail.id}`;
     },
     pageInformation() {
       return this.isTemplate ? pageInformationTemplate
@@ -314,6 +330,16 @@ export default {
         .then(() => {
           this.memo = Object.assign({}, this.memoDetail);
           this.isDataReceived = true;
+          this.breadCrumbs = [
+            {
+              title: this.memoDetail.folderInformation.name,
+              to: `/matchup/${this.memoDetail.folderInformation.id}/memos`,
+            },
+            {
+              title: "テンプレート編集",
+              notOmit: true
+            }
+          ];
         })
         .catch(() => {
           this.displayAlert({ alertStatus: serverErrorAlertStatus });
@@ -325,6 +351,19 @@ export default {
         .then(() => {
           this.memo = Object.assign({}, this.memoDetail);
           this.isDataReceived = true;
+          this.breadCrumbs = [
+            {
+              title: this.memoDetail.folderInformation.name,
+              to: this.memosIndexPath
+            },
+            {
+              title: this.memoDetail.title,
+              to: this.memosShowPath
+            },
+            {
+              title: "編集"
+            }
+          ];
         })
         .catch(() => {
           this.displayAlert({ alertStatus: serverErrorAlertStatus });

--- a/app/frontend/pages/memos/common/MemosShow.vue
+++ b/app/frontend/pages/memos/common/MemosShow.vue
@@ -1,5 +1,9 @@
 <template>
   <template v-if="isDataReceived">
+    <BreadCrumbs
+      :bread-crumbs="breadCrumbs"
+    />
+
     <div class="text-md-h3 text-h4 font-weight-bold">
       {{ memoDetail.title }}
     </div>
@@ -152,12 +156,14 @@
 import { mapGetters, mapActions } from 'vuex';
 import { serverErrorAlertStatus } from '../../../constants/alertStatus';
 import EmbedYoutube from '../components/EmbedYoutube';
+import BreadCrumbs from '../../../components/BreadCrumbs';
 import { sanitizeText } from '../../../plugins/sanitizeText';
 
 export default {
   name: "MemosShow",
   components: {
-    EmbedYoutube
+    EmbedYoutube,
+    BreadCrumbs
   },
   data() {
     return {
@@ -169,6 +175,7 @@ export default {
         indexRouteName: "StrategyMemosIndex",
         editRouteName: "StrategyMemosEdit"
       },
+      breadcrumbs: [],
       memoDeleteDialog: false,
       isDataReceived: false
     };
@@ -177,6 +184,10 @@ export default {
     ...mapGetters("memos", ["memoDetail"]),
     isMatchup() {
       return this.$route.name == "MatchupMemosShow";
+    },
+    memosIndexPath() {
+      const memoType = this.isMatchup ? "matchup" : "strategy";
+      return `/${memoType}/${this.memoDetail.folderInformation.id}/memos`;
     },
     pageInformation() {
       return this.isMatchup ? this.pageInformationMatchup : this.pageInformationStrategy;
@@ -189,6 +200,15 @@ export default {
     this.fetchMemoDetail(this.memoId)
       .then(() => {
           this.isDataReceived = true;
+          this.breadCrumbs = [
+            {
+              title: this.memoDetail.folderInformation.name,
+              to: this.memosIndexPath
+            },
+            {
+              title: this.memoDetail.title
+            }
+          ];
       })
       .catch(() => {
         this.displayAlert({ alertStatus: serverErrorAlertStatus });

--- a/app/frontend/pages/users/ProfileEdit.vue
+++ b/app/frontend/pages/users/ProfileEdit.vue
@@ -151,7 +151,7 @@ export default {
           } else {
             this.displayAlert({ alertStatus: serverErrorAlertStatus });
           }
-        })
+        });
     }
   }
 };

--- a/app/models/memo.rb
+++ b/app/models/memo.rb
@@ -38,4 +38,11 @@ class Memo < ApplicationRecord
     end
     string
   end
+
+  def folder_information
+    {
+      id: folder.id,
+      name: folder.name
+    }
+  end
 end


### PR DESCRIPTION
### 概要
- メモ詳細ページと編集ページにパンくずリストを追加

### 確認項目
- パンくずリストにフォルダのタイトルとメモのタイトルが表示されること
- パンくずリストのリンクをクリックすると、該当のページに遷移すること